### PR TITLE
8: Enable hot reload with Reflex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ run:
 build:
 	@go build
 
+watch:
+	@reflex -s -r '\.go$$' make run
+
 clean:
 	@rm split-the-bill-server
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - open the terminal
 - run `go install github.com/cespare/reflex@latest`  
 
+---
+
 # Start Application
 
 ## Ephemeral Storage

--- a/README.md
+++ b/README.md
@@ -3,8 +3,17 @@
 [![Go Webserver Testing](https://github.com/lab-64/split-the-bill-server/actions/workflows/go.yml/badge.svg)](https://github.com/lab-64/split-the-bill-server/actions/workflows/go.yml)
 
 ---
+# Developer Get Started
+**1. Install Go**
+- follow the instructions: https://go.dev/doc/install
+
+**2. Clone the repository**
+
+**3. Install Reflex package (needed for Hot Reload)**
+- open the terminal
+- run `go install github.com/cespare/reflex@latest`  
+
 # Start Application
-We can start the application with different storage types.
 
 ## Ephemeral Storage
 
@@ -15,7 +24,7 @@ storage := ephemeral.NewEphemeral()
 ```
 Start the application with:
 ```shell
-make run
+make watch
 ```
 
 ## Postgres Database


### PR DESCRIPTION
Fügt Hot Reload hinzu. PR in bill-creation statt dev, weil dev etwas hinterherhinkt.

Es muss zuerst lokal das Reflex package installiert werden: `go install github.com/cespare/reflex@latest`

Das Projekt kann dann mit `make watch` gestartet werden; die Codeänderungen werden nun automatisch erkannt und der Server neu gebildet.

