### PR TITLE
35: Use env variable for storage type

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
+# STORAGE
+#STORAGE_TYPE=ephemeral
+STORAGE_TYPE=postgres
+
+# POSTGRES
 DB_HOST=db
 DB_PORT=5432
 DB_USER=postgres

--- a/README.md
+++ b/README.md
@@ -10,51 +10,36 @@
 **2. Clone the repository**
 
 **3. Install [Reflex](https://github.com/cespare/reflex) package (needed for Hot Reload)**
-- run `go install github.com/cespare/reflex@latest` in the terminal 
+- run `go install github.com/cespare/reflex@latest` 
 
 **4. Install [swag](https://github.com/swaggo/swag) package (needed for fiber-swagger)**
 - run `go install github.com/swaggo/swag/cmd/swag@latest`
-
-
 ---
 
 # Start Application
+**1. Set storage type in `.env`:**
+- `STORAGE_TYPE=ephemeral` for Ephemeral
+- `STORAGE_TYPE=postgres` for Postgres
 
-## Ephemeral Storage
-
-Add the following code in the "select storage" section in `main.go`:
-```go
-// Select storage
-storage := ephemeral.NewEphemeral()
-```
-Start the application with:
-```shell
-make watch
-```
-
-## Postgres Database
-
-Add the following code in the "select storage" section in `main.go`:
-```go
-// Select storage
-storage, err := database.NewDatabase()
-if err != nil {
-    log.Fatal(err)
-}
-```
-
-Start the application with:
+**2a. Start the application (docker, ephemeral & postgres) with:**
 ```shell
 make start-postgres
 ```
-End the application with:
+
+**2b. (OR) Start the application (no docker, ephemeral only) with:**
+```shell
+make watch
+```
+**3. Stop the application with:**
 ```shell
 make stop-postgres
 ```
-Reset the database with:
+
+**4. Reset the database with:**
 ```shell
 make reset-db
 ```
+
 ---
 # Testing
 


### PR DESCRIPTION
I decided to use an env variable instead of a build flag. Reasons:

- .env is the file where a developer would intuitive search for a setting like this, not build flags
- this way we can change the storage type without rebuilding the docker image

Closes #35 