### PR TITLE
26: Add middleware for user auth

### DIFF
--- a/authentication/cookies.go
+++ b/authentication/cookies.go
@@ -2,13 +2,66 @@ package authentication
 
 import (
 	"errors"
+	"fmt"
+	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"split-the-bill-server/http"
+	"split-the-bill-server/storage"
 	"split-the-bill-server/types"
 	"time"
 )
 
 const SessionCookieValidityPeriod = time.Hour * 24 * 7
 const SessionCookieName = "session_cookie"
+const ErrMsgAuthentication = "Authentication declined: %v"
+const ErrMsgNoCookie = "Authentication cookie is missing"
+const ErrMsgInvalidCookie = "Authentication cookie is invalid"
+
+var SessionExpiredError = errors.New("session expired")
+
+type Authenticator struct {
+	storage.ICookieStorage
+}
+
+func NewAuthenticator(cookieStorage *storage.ICookieStorage) *Authenticator {
+	return &Authenticator{ICookieStorage: *cookieStorage}
+}
+
+// Authenticate checks if the user is authenticated.
+// It validates the session cookie, retrieves the authentication cookie, and proceeds if authentication is successful.
+func (a *Authenticator) Authenticate(c *fiber.Ctx) error {
+	cookie := c.Cookies(SessionCookieName)
+	if cookie == "" {
+		return http.Error(c, fiber.StatusUnauthorized, ErrMsgNoCookie)
+	}
+
+	tokenUUID, err := uuid.Parse(cookie)
+	if err != nil {
+		return http.Error(c, fiber.StatusUnauthorized, ErrMsgInvalidCookie)
+	}
+
+	// get auth cookie from storage
+	sessionCookie, err := a.ICookieStorage.GetCookieFromToken(tokenUUID)
+
+	if err != nil {
+		return http.Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgAuthentication, err))
+	}
+
+	err = isSessionCookieValid(sessionCookie)
+
+	if err != nil {
+		return http.Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgAuthentication, err))
+	}
+
+	// go to the next handler
+	err = c.Next()
+
+	if err != nil {
+		return err
+	}
+
+	return err
+}
 
 func GenerateSessionCookie(userID uuid.UUID) types.AuthenticationCookie {
 	// TODO: Safely generate a session cookie.
@@ -19,13 +72,11 @@ func GenerateSessionCookie(userID uuid.UUID) types.AuthenticationCookie {
 	}
 }
 
-// IsSessionCookieValid validates the given session cookie by checking if the ValidBefore time is in the future. Returns SessionExpiredError if the cookie is not valid anymore.
-func IsSessionCookieValid(cookie types.AuthenticationCookie) error {
+// isSessionCookieValid validates the given session cookie by checking if the ValidBefore time is in the future. Returns SessionExpiredError if the cookie is not valid anymore.
+func isSessionCookieValid(cookie types.AuthenticationCookie) error {
 	if cookie.ValidBefore.After(time.Now()) {
 		return nil
 	} else {
 		return SessionExpiredError
 	}
 }
-
-var SessionExpiredError = errors.New("session expired")

--- a/dto/invitation.go
+++ b/dto/invitation.go
@@ -3,7 +3,8 @@ package dto
 import "github.com/google/uuid"
 
 type InvitationInputDTO struct {
-	Type   string    `json:"type"`
 	ID     uuid.UUID `json:"id"`
+	User   uuid.UUID `json:"user"`
+	Type   string    `json:"type"`
 	Accept bool      `json:"accept"`
 }

--- a/handler/messages.go
+++ b/handler/messages.go
@@ -34,7 +34,6 @@ const (
 	ErrMsgUserCredentialsParse = "Could not parse credentials: %v"
 	ErrMsgInvitationParse      = "Could not parse invitation: %v"
 	ErrMsgInvitationHandle     = "Could not handle invitation: %v"
-	ErrMsgAuthentication       = "Authentication declined: %v"
 	ErrMsgBadPassword          = "Bad Password: %v"
 
 	// User - SUCCESS

--- a/main.go
+++ b/main.go
@@ -54,8 +54,11 @@ func main() {
 	// setup logger
 	app.Use(logger.New())
 
+	// authenticator
+	authenticator := authentication.NewAuthenticator(&cookieStorage)
+
 	// routing
-	router.SetupRoutes(app, *userHandler, *groupHandler, *billHandler)
+	router.SetupRoutes(app, *userHandler, *groupHandler, *billHandler, *authenticator)
 
 	// setup swagger
 	app.Get("/swagger/*", swagger.HandlerDefault) // default

--- a/main_test.go
+++ b/main_test.go
@@ -39,8 +39,11 @@ func TestLandingPage(t *testing.T) {
 	groupHandler := handler.NewGroupHandler(&userService, &groupService)
 	billHandler := handler.NewBillHandler(&billService, &groupService)
 
+	// authenticator
+	authenticator := authentication.NewAuthenticator(&cookieStorage)
+
 	//routing
-	router.SetupRoutes(app, *userHandler, *groupHandler, *billHandler)
+	router.SetupRoutes(app, *userHandler, *groupHandler, *billHandler, *authenticator)
 
 	// Create a new http get request on landingpage
 	req := httptest.NewRequest("GET", "/", nil)

--- a/router/router.go
+++ b/router/router.go
@@ -2,11 +2,12 @@ package router
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"split-the-bill-server/authentication"
 	"split-the-bill-server/handler"
 )
 
 // SetupRoutes creates webserver routes and connect them to the related handlers.
-func SetupRoutes(app *fiber.App, u handler.UserHandler, g handler.GroupHandler, b handler.BillHandler) {
+func SetupRoutes(app *fiber.App, u handler.UserHandler, g handler.GroupHandler, b handler.BillHandler, a authentication.Authenticator) {
 
 	// Define landing page
 	app.Get("/", func(c *fiber.Ctx) error {
@@ -20,25 +21,25 @@ func SetupRoutes(app *fiber.App, u handler.UserHandler, g handler.GroupHandler, 
 	userRoute := api.Group("/user")
 
 	// routes
-	userRoute.Get("/", u.GetAll)
-	userRoute.Get("/:id", u.GetByID)
-	userRoute.Post("/", u.Create)
-	userRoute.Get("/:username", u.GetByUsername)
+	userRoute.Get("/", a.Authenticate, u.GetAll)
+	userRoute.Get("/:id", a.Authenticate, u.GetByID)
+	userRoute.Post("/", a.Authenticate, u.Create)
+	userRoute.Get("/:username", a.Authenticate, u.GetByUsername)
 	userRoute.Post("/register", u.Register)
 	userRoute.Post("/login", u.Login)
 	//userRoute.Put("/:id", u.UpdateUser)
-	userRoute.Delete("/:id", u.Delete)
-	userRoute.Post("/invitations", u.HandleInvitation)
+	userRoute.Delete("/:id", a.Authenticate, u.Delete)
+	userRoute.Post("/invitations", a.Authenticate, u.HandleInvitation)
 
 	// bill routes
 	billRoute := api.Group("/bill")
 	// routes
-	billRoute.Post("/", b.Create)
-	billRoute.Get("/:id", b.GetByID)
+	billRoute.Post("/", a.Authenticate, b.Create)
+	billRoute.Get("/:id", a.Authenticate, b.GetByID)
 
 	// group routes
 	groupRoute := api.Group("/group")
 	// routes
-	groupRoute.Post("/", g.Create)
-	groupRoute.Get("/:id", g.Get)
+	groupRoute.Post("/", a.Authenticate, g.Create)
+	groupRoute.Get("/:id", a.Authenticate, g.Get)
 }

--- a/service/impl/user_service.go
+++ b/service/impl/user_service.go
@@ -103,24 +103,8 @@ func (u *UserService) Login(credentials dto.CredentialsInputDTO) (fiber.Cookie, 
 	return cookie, err
 }
 
-func (u *UserService) HandleInvitation(invitation dto.InvitationInputDTO, userID uuid.UUID, invitationID uuid.UUID) error {
-	err := u.IUserStorage.HandleInvitation(invitation.Type, userID, invitationID, invitation.Accept)
+func (u *UserService) HandleInvitation(invitation dto.InvitationInputDTO) error {
+	err := u.IUserStorage.HandleInvitation(invitation.Type, invitation.User, invitation.ID, invitation.Accept)
 	common.LogError(err)
 	return err
-}
-
-func (u *UserService) GetAuthenticatedUserID(tokenID uuid.UUID) (uuid.UUID, error) {
-	// get auth cookie from storage
-	cookie, err := u.ICookieStorage.GetCookieFromToken(tokenID)
-	common.LogError(err)
-
-	// check if cookie is valid
-	err = authentication.IsSessionCookieValid(cookie)
-	common.LogError(err)
-
-	// get user from cookie
-	user, err := u.IUserStorage.GetByID(cookie.UserID)
-	common.LogError(err)
-
-	return user.ID, err
 }

--- a/service/user_service_inf.go
+++ b/service/user_service_inf.go
@@ -21,7 +21,5 @@ type IUserService interface {
 
 	Register(user dto.UserInputDTO) (dto.UserOutputDTO, error)
 
-	HandleInvitation(invitation dto.InvitationInputDTO, userID uuid.UUID, invitationID uuid.UUID) error
-
-	GetAuthenticatedUserID(tokenUUID uuid.UUID) (uuid.UUID, error)
+	HandleInvitation(invitation dto.InvitationInputDTO) error
 }

--- a/storage/database/cookie_storage.go
+++ b/storage/database/cookie_storage.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"split-the-bill-server/storage"
@@ -33,8 +34,18 @@ func (c *CookieStorage) GetCookiesForUser(userID uuid.UUID) []types.Authenticati
 }
 
 func (c *CookieStorage) GetCookieFromToken(token uuid.UUID) (types.AuthenticationCookie, error) {
-	//TODO implement me
-	panic("implement me")
+	var cookie AuthCookie
+
+	tx := c.DB.First(&cookie, token)
+
+	if tx.Error != nil {
+		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+			return types.AuthenticationCookie{}, gorm.ErrRecordNotFound
+		}
+		return types.AuthenticationCookie{}, tx.Error
+	}
+
+	return cookie.ToAuthCookie(), nil
 }
 
 // CookiesToAuthCookies converts a slice of AuthCookie to a slice of types.AuthenticationCookie


### PR DESCRIPTION
Adds a middleware for user authentication.

I also made some changes to the HandleInvitation endpoint to keep it functional since the Authenticate method doesn't return the userID anymore. Instead the creatorID from input DTO is used. This code probably won't last long since we are going to refactor the invitation section.

In the next step we have to think about how to verify if a requester has permissions to i. e. create some resource.  

Closes #25 
Closes #26 