### PR TITLE
82: Include bills instead of uuids in GroupOutputDTO

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -530,7 +530,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.InvitationResponseDTO"
+                            "$ref": "#/definitions/dto.InvitationResponseInputDTO"
                         }
                     }
                 ],
@@ -829,10 +829,10 @@ const docTemplate = `{
         "dto.GroupOutputDTO": {
             "type": "object",
             "properties": {
-                "billIDs": {
+                "bills": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/dto.BillOutputDTO"
                     }
                 },
                 "id": {
@@ -852,7 +852,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvitationResponseDTO": {
+        "dto.InvitationResponseInputDTO": {
             "type": "object",
             "properties": {
                 "isAccept": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -523,7 +523,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.InvitationResponseDTO"
+                            "$ref": "#/definitions/dto.InvitationResponseInputDTO"
                         }
                     }
                 ],
@@ -822,10 +822,10 @@
         "dto.GroupOutputDTO": {
             "type": "object",
             "properties": {
-                "billIDs": {
+                "bills": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/dto.BillOutputDTO"
                     }
                 },
                 "id": {
@@ -845,7 +845,7 @@
                 }
             }
         },
-        "dto.InvitationResponseDTO": {
+        "dto.InvitationResponseInputDTO": {
             "type": "object",
             "properties": {
                 "isAccept": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -70,9 +70,9 @@ definitions:
     type: object
   dto.GroupOutputDTO:
     properties:
-      billIDs:
+      bills:
         items:
-          type: string
+          $ref: '#/definitions/dto.BillOutputDTO'
         type: array
       id:
         type: string
@@ -85,7 +85,7 @@ definitions:
       ownerID:
         type: string
     type: object
-  dto.InvitationResponseDTO:
+  dto.InvitationResponseInputDTO:
     properties:
       isAccept:
         type: boolean
@@ -419,7 +419,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.InvitationResponseDTO'
+          $ref: '#/definitions/dto.InvitationResponseInputDTO'
       produces:
       - application/json
       responses:

--- a/domain/model/group.go
+++ b/domain/model/group.go
@@ -9,7 +9,7 @@ type GroupModel struct {
 	Owner   uuid.UUID
 	Name    string
 	Members []uuid.UUID
-	Bills   []uuid.UUID
+	Bills   []BillModel
 }
 
 func CreateGroupModel(owner uuid.UUID, name string, members []uuid.UUID) GroupModel {
@@ -18,6 +18,5 @@ func CreateGroupModel(owner uuid.UUID, name string, members []uuid.UUID) GroupMo
 		ID:      uuid.New(),
 		Name:    name,
 		Members: members,
-		Bills:   make([]uuid.UUID, 0),
 	}
 }

--- a/domain/service/impl/group_service.go
+++ b/domain/service/impl/group_service.go
@@ -22,7 +22,7 @@ func (g *GroupService) Create(groupDTO GroupInputDTO) (GroupOutputDTO, error) {
 	group := ToGroupModel(groupDTO)
 
 	// store group in db
-	err := g.groupStorage.AddGroup(group)
+	group, err := g.groupStorage.AddGroup(group)
 	if err != nil {
 		return GroupOutputDTO{}, err
 	}

--- a/presentation/dto/group.go
+++ b/presentation/dto/group.go
@@ -12,11 +12,11 @@ type GroupInputDTO struct {
 }
 
 type GroupOutputDTO struct {
-	Owner   UUID   `json:"ownerID"`
-	ID      UUID   `json:"id"`
-	Name    string `json:"name"`
-	Members []UUID `json:"memberIDs"`
-	Bills   []UUID `json:"billIDs"`
+	Owner   UUID            `json:"ownerID"`
+	ID      UUID            `json:"id"`
+	Name    string          `json:"name"`
+	Members []UUID          `json:"memberIDs"`
+	Bills   []BillOutputDTO `json:"bills"`
 }
 
 func ToGroupModel(g GroupInputDTO) GroupModel {
@@ -25,12 +25,18 @@ func ToGroupModel(g GroupInputDTO) GroupModel {
 
 func ToGroupDTO(g GroupModel) GroupOutputDTO {
 
+	billsDTO := make([]BillOutputDTO, len(g.Bills))
+
+	for i, bill := range g.Bills {
+		billsDTO[i] = ToBillDTO(bill)
+	}
+
 	return GroupOutputDTO{
 		Owner:   g.Owner,
 		ID:      g.ID,
 		Name:    g.Name,
 		Members: g.Members,
-		Bills:   g.Bills,
+		Bills:   billsDTO,
 	}
 }
 

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -49,7 +49,7 @@ func (h GroupHandler) Create(c *fiber.Ctx) error {
 		return core.Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgGroupCreate, err))
 	}
 
-	return core.Success(c, fiber.StatusOK, SuccessMsgGroupCreate, group)
+	return core.Success(c, fiber.StatusCreated, SuccessMsgGroupCreate, group)
 }
 
 // GetByID returns the group with the given ID.

--- a/presentation/handler/invitation_handler.go
+++ b/presentation/handler/invitation_handler.go
@@ -101,7 +101,7 @@ func (h InvitationHandler) Create(c *fiber.Ctx) error {
 //	@Tags		Invitation
 //	@Accept		json
 //	@Produce	json
-//	@Param		id		path		string						true	"Invitation ID"
+//	@Param		id		path		string							true	"Invitation ID"
 //	@Param		request	body		dto.InvitationResponseInputDTO	true	"Request Body"
 //	@Success	200		{object}	dto.GeneralResponseDTO
 //	@Router		/api/invitation/{id}/response [post]

--- a/storage/database/entity/group.go
+++ b/storage/database/entity/group.go
@@ -20,12 +20,8 @@ func ToGroupEntity(group GroupModel) Group {
 	for _, member := range group.Members {
 		members = append(members, &User{Base: Base{ID: member}})
 	}
-	// convert uuids to bills
-	var bills []Bill
-	for _, bill := range group.Bills {
-		bills = append(bills, Bill{Base: Base{ID: bill}})
-	}
-	return Group{Base: Base{ID: group.ID}, OwnerUID: group.Owner, Name: group.Name, Members: members, Bills: bills}
+
+	return Group{Base: Base{ID: group.ID}, OwnerUID: group.Owner, Name: group.Name, Members: members}
 }
 
 func ToGroupModel(group *Group) GroupModel {
@@ -34,12 +30,14 @@ func ToGroupModel(group *Group) GroupModel {
 	for _, member := range group.Members {
 		members = append(members, member.ID)
 	}
-	// convert bills to uuids
-	var billIDs []uuid.UUID
+
+	// convert bills
+	var bills []BillModel
 	for _, bill := range group.Bills {
-		billIDs = append(billIDs, bill.ID)
+		bills = append(bills, ToBillModel(bill))
 	}
-	return GroupModel{ID: group.ID, Owner: group.OwnerUID, Name: group.Name, Members: members, Bills: billIDs}
+
+	return GroupModel{ID: group.ID, Owner: group.OwnerUID, Name: group.Name, Members: members, Bills: bills}
 }
 
 func ToGroupModelSlice(groups []Group) []GroupModel {

--- a/storage/ephemeral/eph_storages/group_storage.go
+++ b/storage/ephemeral/eph_storages/group_storage.go
@@ -16,15 +16,15 @@ func NewGroupStorage(ephemeral *ephemeral.Ephemeral) storage_inf.IGroupStorage {
 	return &GroupStorage{e: ephemeral}
 }
 
-func (g *GroupStorage) AddGroup(group model.GroupModel) error {
+func (g *GroupStorage) AddGroup(group model.GroupModel) (model.GroupModel, error) {
 	g.e.Lock.Lock()
 	defer g.e.Lock.Unlock()
 	_, exists := g.e.Groups[group.ID]
 	if exists {
-		return storage.GroupAlreadyExistsError
+		return model.GroupModel{}, storage.GroupAlreadyExistsError
 	}
 	g.e.Groups[group.ID] = &group
-	return nil
+	return group, nil
 }
 
 func (g *GroupStorage) GetGroupByID(id uuid.UUID) (model.GroupModel, error) {

--- a/storage/storage_inf/group_storage_inf.go
+++ b/storage/storage_inf/group_storage_inf.go
@@ -7,7 +7,7 @@ import (
 
 type IGroupStorage interface {
 	// AddGroup adds the given group to the storage. If a group with the same ID or name already exists, a GroupAlreadyExistsError is returned.
-	AddGroup(group GroupModel) error
+	AddGroup(group GroupModel) (GroupModel, error)
 
 	// GetGroupByID returns the group with the given ID, or a NoSuchGroupError if no such group exists.
 	GetGroupByID(id UUID) (GroupModel, error)


### PR DESCRIPTION
We return the full detailed group DTO for both GET group/{id} and GET group/?userID=...

Whether this will be needed depends on the frontend's requirements. We can optimize later (if that's necessary at all) 