### PR TITLE
87:  PUT /group/{id} endpoint and basic authorization

### DIFF
--- a/authentication/cookies.go
+++ b/authentication/cookies.go
@@ -53,6 +53,9 @@ func (a *Authenticator) Authenticate(c *fiber.Ctx) error {
 		return core.Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgAuthentication, err))
 	}
 
+	// set userID in context
+	c.Locals("userID", sessionCookie.UserID)
+
 	// go to the next handler
 	err = c.Next()
 

--- a/authentication/cookies.go
+++ b/authentication/cookies.go
@@ -13,7 +13,7 @@ import (
 
 const SessionCookieValidityPeriod = time.Hour * 24 * 7
 const SessionCookieName = "session_cookie"
-const UserID = "user_id"
+const UserKey = "user_key"
 const ErrMsgAuthentication = "Authentication declined: %v"
 const ErrMsgNoCookie = "Authentication cookie is missing"
 const ErrMsgInvalidCookie = "Authentication cookie is invalid"
@@ -55,7 +55,7 @@ func (a *Authenticator) Authenticate(c *fiber.Ctx) error {
 	}
 
 	// set userID in context
-	c.Locals(UserID, sessionCookie.UserID)
+	c.Locals(UserKey, sessionCookie.UserID)
 
 	// go to the next handler
 	err = c.Next()

--- a/authentication/cookies.go
+++ b/authentication/cookies.go
@@ -13,6 +13,7 @@ import (
 
 const SessionCookieValidityPeriod = time.Hour * 24 * 7
 const SessionCookieName = "session_cookie"
+const UserID = "user_id"
 const ErrMsgAuthentication = "Authentication declined: %v"
 const ErrMsgNoCookie = "Authentication cookie is missing"
 const ErrMsgInvalidCookie = "Authentication cookie is invalid"
@@ -54,7 +55,7 @@ func (a *Authenticator) Authenticate(c *fiber.Ctx) error {
 	}
 
 	// set userID in context
-	c.Locals("userID", sessionCookie.UserID)
+	c.Locals(UserID, sessionCookie.UserID)
 
 	// go to the next handler
 	err = c.Next()

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -368,6 +368,56 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request Body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupInputDTO"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.GeneralResponseDTO"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.GroupDetailedOutputDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
             }
         },
         "/api/invitation": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -250,7 +250,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
                 "summary": "Get Groups by User",
                 "parameters": [
@@ -291,9 +291,9 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
-                "summary": "Create GroupID",
+                "summary": "Create Group",
                 "parameters": [
                     {
                         "description": "Request Body",
@@ -336,13 +336,13 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
-                "summary": "Get GroupID by ID",
+                "summary": "Get Group by ID",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "GroupID Id",
+                        "description": "Group Id",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -431,7 +431,7 @@ const docTemplate = `{
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Create GroupID Invitation",
+                "summary": "Create Group Invitation",
                 "parameters": [
                     {
                         "description": "Request Body",
@@ -476,7 +476,7 @@ const docTemplate = `{
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Get All GroupID Invitations From User",
+                "summary": "Get All Group Invitations From User",
                 "parameters": [
                     {
                         "type": "string",
@@ -522,7 +522,7 @@ const docTemplate = `{
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Get GroupID Invitation By ID",
+                "summary": "Get Group Invitation By ID",
                 "parameters": [
                     {
                         "type": "string",
@@ -565,7 +565,7 @@ const docTemplate = `{
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Accept or decline GroupID Invitation",
+                "summary": "Accept or decline Group Invitation",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -361,6 +361,56 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Update Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request Body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.GroupInputDTO"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.GeneralResponseDTO"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/dto.GroupDetailedOutputDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
             }
         },
         "/api/invitation": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -243,7 +243,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
                 "summary": "Get Groups by User",
                 "parameters": [
@@ -284,9 +284,9 @@
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
-                "summary": "Create GroupID",
+                "summary": "Create Group",
                 "parameters": [
                     {
                         "description": "Request Body",
@@ -329,13 +329,13 @@
                     "application/json"
                 ],
                 "tags": [
-                    "GroupID"
+                    "Group"
                 ],
-                "summary": "Get GroupID by ID",
+                "summary": "Get Group by ID",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "GroupID Id",
+                        "description": "Group Id",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -424,7 +424,7 @@
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Create GroupID Invitation",
+                "summary": "Create Group Invitation",
                 "parameters": [
                     {
                         "description": "Request Body",
@@ -469,7 +469,7 @@
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Get All GroupID Invitations From User",
+                "summary": "Get All Group Invitations From User",
                 "parameters": [
                     {
                         "type": "string",
@@ -515,7 +515,7 @@
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Get GroupID Invitation By ID",
+                "summary": "Get Group Invitation By ID",
                 "parameters": [
                     {
                         "type": "string",
@@ -558,7 +558,7 @@
                 "tags": [
                     "Invitation"
                 ],
-                "summary": "Accept or decline GroupID Invitation",
+                "summary": "Accept or decline Group Invitation",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -373,6 +373,36 @@ paths:
       summary: Get Group by ID
       tags:
       - Group
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request Body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.GroupInputDTO'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/dto.GeneralResponseDTO'
+            - properties:
+                data:
+                  $ref: '#/definitions/dto.GroupDetailedOutputDTO'
+              type: object
+      summary: Update Group
+      tags:
+      - Group
   /api/invitation:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -324,7 +324,7 @@ paths:
               type: object
       summary: Get Groups by User
       tags:
-      - GroupID
+      - Group
     post:
       consumes:
       - application/json
@@ -355,7 +355,7 @@ paths:
       consumes:
       - application/json
       parameters:
-      - description: GroupID Id
+      - description: Group Id
         in: path
         name: id
         required: true

--- a/domain/service/impl/errors.go
+++ b/domain/service/impl/errors.go
@@ -1,0 +1,5 @@
+package impl
+
+import "errors"
+
+var ErrNotAuthorized = errors.New("not Authorized")

--- a/domain/service/impl/group_service.go
+++ b/domain/service/impl/group_service.go
@@ -30,6 +30,30 @@ func (g *GroupService) Create(groupDTO GroupInputDTO) (GroupDetailedOutputDTO, e
 	return ToGroupDetailedDTO(group), nil
 }
 
+func (g *GroupService) Update(userID UUID, groupID UUID, groupDTO GroupInputDTO) (GroupDetailedOutputDTO, error) {
+	group, err := g.groupStorage.GetGroupByID(groupID)
+
+	if err != nil {
+		return GroupDetailedOutputDTO{}, err
+	}
+
+	// Validate
+	if userID != group.Owner.ID {
+		return GroupDetailedOutputDTO{}, ErrNotAuthorized
+	}
+
+	// Update fields
+	group.Name = groupDTO.Name
+	group.Owner.ID = groupDTO.OwnerID
+
+	group, err = g.groupStorage.UpdateGroup(group)
+	if err != nil {
+		return GroupDetailedOutputDTO{}, err
+	}
+
+	return ToGroupDetailedDTO(group), err
+}
+
 func (g *GroupService) GetByID(id UUID) (GroupDetailedOutputDTO, error) {
 	group, err := g.groupStorage.GetGroupByID(id)
 	if err != nil {

--- a/domain/service/impl/group_service.go
+++ b/domain/service/impl/group_service.go
@@ -37,7 +37,7 @@ func (g *GroupService) Update(userID UUID, groupID UUID, groupDTO GroupInputDTO)
 		return GroupDetailedOutputDTO{}, err
 	}
 
-	// Validate
+	// Authorize
 	if userID != group.Owner.ID {
 		return GroupDetailedOutputDTO{}, ErrNotAuthorized
 	}

--- a/domain/service/service_inf/group_service_inf.go
+++ b/domain/service/service_inf/group_service_inf.go
@@ -8,6 +8,8 @@ import (
 type IGroupService interface {
 	Create(groupDTO GroupInputDTO) (GroupDetailedOutputDTO, error)
 
+	Update(userID UUID, groupID UUID, group GroupInputDTO) (GroupDetailedOutputDTO, error)
+
 	GetByID(id UUID) (GroupDetailedOutputDTO, error)
 
 	GetAllByUser(userID UUID) ([]GroupDetailedOutputDTO, error)

--- a/presentation/dto/group.go
+++ b/presentation/dto/group.go
@@ -7,8 +7,8 @@ import (
 )
 
 type GroupInputDTO struct {
-	Owner UUID   `json:"ownerID"`
-	Name  string `json:"name"`
+	OwnerID UUID   `json:"ownerID"`
+	Name    string `json:"name"`
 }
 
 type GroupCoreOutputDTO struct {
@@ -27,7 +27,7 @@ type GroupDetailedOutputDTO struct {
 }
 
 func ToGroupModel(g GroupInputDTO) GroupModel {
-	return CreateGroupModel(g.Owner, g.Name, []UUID{g.Owner})
+	return CreateGroupModel(g.OwnerID, g.Name, []UUID{g.OwnerID})
 }
 
 func ToGroupCoreDTO(g GroupModel) GroupCoreOutputDTO {

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -52,6 +52,46 @@ func (h GroupHandler) Create(c *fiber.Ctx) error {
 	return core.Success(c, fiber.StatusCreated, SuccessMsgGroupCreate, group)
 }
 
+// Update updates a group with the given id.
+//
+//	@Summary	Update Group
+//	@Tags		Group
+//	@Accept		json
+//	@Produce	json
+//	@Param		id		path		string				true	"Group ID"
+//	@Param		request	body		dto.GroupInputDTO	true	"Request Body"
+//	@Success	200		{object}	dto.GeneralResponseDTO{data=dto.GroupDetailedOutputDTO}
+//
+//	@Router		/api/group/{id} [put]
+func (g GroupHandler) Update(c *fiber.Ctx) error {
+	// parse parameters
+	id := c.Params("id")
+	if id == "" {
+		return core.Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParameterRequired, "id"))
+	}
+
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return core.Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParseUUID, uid, err))
+	}
+
+	// parse request
+	var request GroupInputDTO
+	if err := c.BodyParser(&request); err != nil {
+		return core.Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgGroupParse, err))
+	}
+
+	userID := c.Locals("userID").(uuid.UUID)
+
+	// update item
+	item, err := g.groupService.Update(userID, uid, request)
+	if err != nil {
+		return core.Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgGroupUpdate, err))
+	}
+
+	return core.Success(c, fiber.StatusOK, SuccessMsgGroupUpdate, item)
+}
+
 // GetByID returns the group with the given ID.
 //
 //	@Summary	Get Group by ID

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -82,7 +82,7 @@ func (g GroupHandler) Update(c *fiber.Ctx) error {
 		return core.Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgGroupParse, err))
 	}
 
-	userID := c.Locals(authentication.UserID).(uuid.UUID)
+	userID := c.Locals(authentication.UserKey).(uuid.UUID)
 
 	// update item
 	item, err := g.groupService.Update(userID, uid, request)

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"split-the-bill-server/authentication"
 	"split-the-bill-server/core"
 	. "split-the-bill-server/domain/service/service_inf"
 	. "split-the-bill-server/presentation/dto"
@@ -81,7 +82,7 @@ func (g GroupHandler) Update(c *fiber.Ctx) error {
 		return core.Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgGroupParse, err))
 	}
 
-	userID := c.Locals("userID").(uuid.UUID)
+	userID := c.Locals(authentication.UserID).(uuid.UUID)
 
 	// update item
 	item, err := g.groupService.Update(userID, uid, request)

--- a/presentation/handler/messages.go
+++ b/presentation/handler/messages.go
@@ -2,14 +2,14 @@ package handler
 
 const (
 	// Generic error messages
-	ErrMsgParameterRequired   = "Parameter %s is required"
-	ErrMsgParseUUID           = "Could not parse uuid: %s, error: %v"
-	ErrMsgInputsInvalid       = "Inputs invalid: %v"
-	ErrMsgParamMismatchFormat = "%s in URL does not match with the request body"
+	ErrMsgParameterRequired = "Parameter %s is required"
+	ErrMsgParseUUID         = "Could not parse uuid: %s, error: %v"
+	ErrMsgInputsInvalid     = "Inputs invalid: %v"
 
 	// Group - ERROR
 	ErrMsgGroupParse    = "Could not parse group: %v"
 	ErrMsgGroupCreate   = "Could not create group: %v"
+	ErrMsgGroupUpdate   = "Could not update group: %v"
 	ErrMsgGroupNotFound = "Group not found: %v"
 	ErrMsgGetUserGroups = "Could not load user groups: %v"
 
@@ -17,6 +17,7 @@ const (
 	SuccessMsgGroupFound  = "Group found"
 	SuccessMsgGroupsFound = "Groups found"
 	SuccessMsgGroupCreate = "Group created"
+	SuccessMsgGroupUpdate = "Group updated"
 
 	// Bill - ERROR
 	ErrMsgBillParse    = "Could not parse bill: %v"

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -44,6 +44,7 @@ func SetupRoutes(app *fiber.App, u UserHandler, g GroupHandler, b BillHandler, i
 	groupRoute := api.Group("/group")
 	// routes
 	groupRoute.Post("/", a.Authenticate, g.Create)
+	groupRoute.Put("/:id", a.Authenticate, g.Update)
 	groupRoute.Get("/:id", a.Authenticate, g.GetByID)
 	groupRoute.Get("/", a.Authenticate, g.GetAllByUser)
 

--- a/storage/database/db_storages/group_storage.go
+++ b/storage/database/db_storages/group_storage.go
@@ -36,6 +36,27 @@ func (g *GroupStorage) AddGroup(group GroupModel) (GroupModel, error) {
 	return ToGroupModel(&groupItem), res.Error
 }
 
+func (g *GroupStorage) UpdateGroup(group GroupModel) (GroupModel, error) {
+	groupEntity := ToGroupEntity(group)
+
+	res := g.DB.
+		Preload(clause.Associations).
+		Model(&groupEntity).
+		Updates(&groupEntity).
+		First(&groupEntity)
+
+	// TODO: add finer error handling
+	if res.Error != nil {
+		return GroupModel{}, res.Error
+	}
+
+	if res.RowsAffected == 0 {
+		return GroupModel{}, storage.NoSuchGroupError
+	}
+
+	return ToGroupModel(&groupEntity), nil
+}
+
 func (g *GroupStorage) GetGroupByID(id uuid.UUID) (GroupModel, error) {
 	var group Group
 

--- a/storage/ephemeral/eph_storages/group_storage.go
+++ b/storage/ephemeral/eph_storages/group_storage.go
@@ -27,6 +27,11 @@ func (g *GroupStorage) AddGroup(group model.GroupModel) (model.GroupModel, error
 	return group, nil
 }
 
+func (g *GroupStorage) UpdateGroup(group model.GroupModel) (model.GroupModel, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (g *GroupStorage) GetGroupByID(id uuid.UUID) (model.GroupModel, error) {
 	g.e.Lock.Lock()
 	defer g.e.Lock.Unlock()

--- a/storage/ephemeral/eph_storages/test/ephemeral_test.go
+++ b/storage/ephemeral/eph_storages/test/ephemeral_test.go
@@ -9,11 +9,11 @@ import (
 func TestEphemeral(t *testing.T) {
 	e, _ := ephemeral.NewEphemeral()
 	userStorage := eph_storages.NewUserStorage(e)
-	UserStorageTest(e, userStorage, t)
+	UserStorageTest(userStorage, t)
 }
 
 func TestEphemeralEdgeCases(t *testing.T) {
 	e, _ := ephemeral.NewEphemeral()
 	userStorage := eph_storages.NewUserStorage(e)
-	UserStorageEdgeCaseTest(e, userStorage, t)
+	UserStorageEdgeCaseTest(userStorage, t)
 }

--- a/storage/ephemeral/eph_storages/test/user_storage_test.go
+++ b/storage/ephemeral/eph_storages/test/user_storage_test.go
@@ -45,12 +45,10 @@ func deleteUsersAndAssert(uut IUserStorage, users []UserModel, t *testing.T, fin
 	close(finished)
 }
 
-func UserStorageTest(e storage.Connection, uut IUserStorage, t *testing.T) {
+func UserStorageTest(uut IUserStorage, t *testing.T) {
 	const amount = 10
 	const concurrency = 10
 	users := types_test.GenerateDifferentUsers(amount)
-	err := e.Connect()
-	require.NoError(t, err)
 	allUsers, err := uut.GetAll()
 	require.NoError(t, err)
 	require.Equal(t, 0, len(allUsers))
@@ -86,11 +84,9 @@ func UserStorageTest(e storage.Connection, uut IUserStorage, t *testing.T) {
 	require.Equal(t, 0, len(allUsers))
 }
 
-func UserStorageEdgeCaseTest(e storage.Connection, uut IUserStorage, t *testing.T) {
-	err := e.Connect()
-	require.NoError(t, err)
+func UserStorageEdgeCaseTest(uut IUserStorage, t *testing.T) {
 	users := types_test.GenerateUsersWithEmails([]string{"a", "a"})
-	err = uut.Delete(users[0].ID)
+	err := uut.Delete(users[0].ID)
 	require.NoError(t, err)
 	pw, err := authentication.HashPassword("ehhh")
 	require.NoError(t, err)

--- a/storage/ephemeral/ephemeral.go
+++ b/storage/ephemeral/ephemeral.go
@@ -27,7 +27,3 @@ func NewEphemeral() (*Ephemeral, error) {
 		Bills:     make(map[uuid.UUID]*model.BillModel),
 	}, nil
 }
-
-func (e *Ephemeral) Connect() error {
-	return nil
-}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -4,13 +4,6 @@ import (
 	"errors"
 )
 
-// TODO: Add generic storage tests
-
-type Connection interface {
-	// Connect connects to the storage and must be called exactly once before interacting with the storage.
-	Connect() error
-}
-
 // User Errors
 var UserAlreadyExistsError = errors.New("user already exists")
 var NoSuchUserError = errors.New("no such user")

--- a/storage/storage_inf/group_storage_inf.go
+++ b/storage/storage_inf/group_storage_inf.go
@@ -9,6 +9,9 @@ type IGroupStorage interface {
 	// AddGroup adds the given group to the storage. If a group with the same ID or name already exists, a GroupAlreadyExistsError is returned.
 	AddGroup(group GroupModel) (GroupModel, error)
 
+	// UpdateGroup updates the group
+	UpdateGroup(group GroupModel) (GroupModel, error)
+
 	// GetGroupByID returns the group with the given ID, or a NoSuchGroupError if no such group exists.
 	GetGroupByID(id UUID) (GroupModel, error)
 


### PR DESCRIPTION
I've added a PUT endpoint for groups. Nothing spectacular. For convenience only name and the owner of the group can be changed.

Much more interesting point is the authorization approach implemented for this endpoint for the first time in our app. 

It's pretty simple:
- our `Authenticate` middleware in `cookies.go` stores the userID retrieved from the cookie in the context (`c.Locals("userID", sessionCookie.UserID`)
- we access this `userID` in `group_handler` and pass it to the service
- service retrieves the group that has to be updated and checks whether the group's owner is equal to `userID` from the cookie. If not a "not authorized" error message is returned.

The assumption is that only the group owner can update it.

You may wonder: why do we pass an extra parameter to the service instead of authorizing directly in the handler? The reason is: handlers should be dumb as fuck. For the authorization we need to retrieve the existing group first (to compare its owner with the requester ID). We don't want a handler to do this. He should only pass needed things to the service. Service is where the magic happens.
 

Closes #87 and deals with #48.