### PR TITLE
127 Remove group from user model

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -999,20 +999,8 @@ const docTemplate = `{
                 "email": {
                     "type": "string"
                 },
-                "groups": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/dto.GroupCoreOutputDTO"
-                    }
-                },
                 "id": {
                     "type": "string"
-                },
-                "invitationIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 },
                 "username": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -992,20 +992,8 @@
                 "email": {
                     "type": "string"
                 },
-                "groups": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/dto.GroupCoreOutputDTO"
-                    }
-                },
                 "id": {
                     "type": "string"
-                },
-                "invitationIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 },
                 "username": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -143,16 +143,8 @@ definitions:
     properties:
       email:
         type: string
-      groups:
-        items:
-          $ref: '#/definitions/dto.GroupCoreOutputDTO'
-        type: array
       id:
         type: string
-      invitationIDs:
-        items:
-          type: string
-        type: array
       username:
         type: string
     type: object

--- a/domain/model/user.go
+++ b/domain/model/user.go
@@ -5,12 +5,9 @@ import (
 )
 
 type UserModel struct {
-	ID                      uuid.UUID
-	Email                   string
-	Username                string
-	PendingGroupInvitations []GroupInvitationModel
-	Groups                  []GroupModel
-	Items                   []ItemModel
+	ID       uuid.UUID
+	Email    string
+	Username string
 }
 
 func CreateUser(id uuid.UUID, email string, username string) UserModel {

--- a/presentation/dto/user.go
+++ b/presentation/dto/user.go
@@ -22,6 +22,7 @@ type UserUpdateDTO struct {
 // Output Section
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// TODO: maybe use only one single DTO for the user output
 type UserCoreOutputDTO struct {
 	ID       uuid.UUID `json:"id"`
 	Email    string    `json:"email"`
@@ -46,31 +47,16 @@ func ConvertToUserCoreDTOs(users []model.UserModel) []UserCoreOutputDTO {
 }
 
 type UserDetailedOutputDTO struct {
-	ID            uuid.UUID            `json:"id"`
-	Email         string               `json:"email"`
-	Username      string               `json:"username"`
-	Groups        []GroupCoreOutputDTO `json:"groups"`
-	InvitationIDs []uuid.UUID          `json:"invitationIDs"`
+	ID       uuid.UUID `json:"id"`
+	Email    string    `json:"email"`
+	Username string    `json:"username"`
 }
 
 func ConvertToUserDetailedDTO(u *model.UserModel) UserDetailedOutputDTO {
-	groupsDTO := make([]GroupCoreOutputDTO, len(u.Groups))
-
-	for i, group := range u.Groups {
-		groupsDTO[i] = ConvertToGroupCoreDTO(group)
-	}
-
-	invitations := make([]uuid.UUID, len(u.PendingGroupInvitations))
-
-	for i, inv := range u.PendingGroupInvitations {
-		invitations[i] = inv.ID
-	}
 
 	return UserDetailedOutputDTO{
-		ID:            u.ID,
-		Email:         u.Email,
-		Username:      u.Username,
-		Groups:        groupsDTO,
-		InvitationIDs: invitations,
+		ID:       u.ID,
+		Email:    u.Email,
+		Username: u.Username,
 	}
 }

--- a/storage/database/db_storages/bill_storage.go
+++ b/storage/database/db_storages/bill_storage.go
@@ -37,7 +37,7 @@ func (b *BillStorage) Create(bill BillModel) (BillModel, error) {
 		return BillModel{}, storage.BillAlreadyExistsError
 	}
 
-	return ConvertToBillModel(item, true), res.Error
+	return ConvertToBillModel(item), res.Error
 }
 
 func (b *BillStorage) UpdateBill(bill BillModel) (BillModel, error) {
@@ -70,7 +70,7 @@ func (b *BillStorage) UpdateBill(bill BillModel) (BillModel, error) {
 		return nil
 	})
 
-	return ConvertToBillModel(billEntity, true), err
+	return ConvertToBillModel(billEntity), err
 }
 
 func (b *BillStorage) GetByID(id uuid.UUID) (BillModel, error) {
@@ -83,7 +83,7 @@ func (b *BillStorage) GetByID(id uuid.UUID) (BillModel, error) {
 	if tx.RowsAffected == 0 {
 		return BillModel{}, storage.NoSuchBillError
 	}
-	billModel := ConvertToBillModel(bill, true)
+	billModel := ConvertToBillModel(bill)
 	return billModel, nil
 }
 
@@ -102,7 +102,7 @@ func (b *BillStorage) CreateItem(item ItemModel) (ItemModel, error) {
 		return ItemModel{}, storage.ItemAlreadyExistsError
 	}
 
-	return ConvertToItemModel(itemEntity, true), nil
+	return ConvertToItemModel(itemEntity), nil
 }
 
 func (b *BillStorage) GetItemByID(id uuid.UUID) (ItemModel, error) {
@@ -111,7 +111,7 @@ func (b *BillStorage) GetItemByID(id uuid.UUID) (ItemModel, error) {
 	if tx.RowsAffected == 0 {
 		return ItemModel{}, storage.NoSuchItemError
 	}
-	return ConvertToItemModel(item, true), nil
+	return ConvertToItemModel(item), nil
 }
 
 func (b *BillStorage) UpdateItem(item ItemModel) (ItemModel, error) {
@@ -147,5 +147,5 @@ func (b *BillStorage) UpdateItem(item ItemModel) (ItemModel, error) {
 		return nil
 	})
 
-	return ConvertToItemModel(itemEntity, true), err
+	return ConvertToItemModel(itemEntity), err
 }

--- a/storage/database/db_storages/group_storage.go
+++ b/storage/database/db_storages/group_storage.go
@@ -32,7 +32,7 @@ func (g *GroupStorage) AddGroup(group GroupModel) (GroupModel, error) {
 	if res.RowsAffected == 0 {
 		return GroupModel{}, storage.GroupAlreadyExistsError
 	}
-	return ConvertToGroupModel(groupItem, true), res.Error
+	return ConvertToGroupModel(groupItem), res.Error
 }
 
 func (g *GroupStorage) UpdateGroup(group GroupModel) (GroupModel, error) {
@@ -53,7 +53,7 @@ func (g *GroupStorage) UpdateGroup(group GroupModel) (GroupModel, error) {
 		return GroupModel{}, storage.NoSuchGroupError
 	}
 
-	return ConvertToGroupModel(groupEntity, true), nil
+	return ConvertToGroupModel(groupEntity), nil
 }
 
 func (g *GroupStorage) GetGroupByID(id uuid.UUID) (GroupModel, error) {
@@ -63,6 +63,7 @@ func (g *GroupStorage) GetGroupByID(id uuid.UUID) (GroupModel, error) {
 	tx := g.DB.
 		Preload(clause.Associations).
 		Preload("Bills.Items.Contributors").
+		Preload("Bills.Owner").
 		Limit(1).Find(&group, "id = ?", id)
 
 	if tx.Error != nil {
@@ -71,7 +72,7 @@ func (g *GroupStorage) GetGroupByID(id uuid.UUID) (GroupModel, error) {
 	if tx.RowsAffected == 0 {
 		return GroupModel{}, storage.NoSuchGroupError
 	}
-	return ConvertToGroupModel(group, true), nil
+	return ConvertToGroupModel(group), nil
 }
 
 func (g *GroupStorage) GetGroupsByUserID(userID uuid.UUID) ([]GroupModel, error) {
@@ -80,6 +81,7 @@ func (g *GroupStorage) GetGroupsByUserID(userID uuid.UUID) ([]GroupModel, error)
 	tx := g.DB.
 		Preload(clause.Associations).
 		Preload("Bills.Items.Contributors").
+		Preload("Bills.Owner").
 		Where("id IN (SELECT group_id FROM group_members WHERE user_id = ?)", userID).
 		Find(&groups)
 

--- a/storage/database/db_storages/invitation_storage.go
+++ b/storage/database/db_storages/invitation_storage.go
@@ -27,7 +27,7 @@ func (i InvitationStorage) AddGroupInvitation(invitation GroupInvitationModel) (
 		return GroupInvitationModel{}, storage.GroupInvitationAlreadyExistsError
 	}
 
-	return ConvertToGroupInvitationModel(groupInvitation, true), res.Error
+	return ConvertToGroupInvitationModel(groupInvitation), res.Error
 }
 
 func (i InvitationStorage) AcceptGroupInvitation(invitationID uuid.UUID, userID uuid.UUID) error {
@@ -58,5 +58,5 @@ func (i InvitationStorage) GetGroupInvitationByID(id uuid.UUID) (GroupInvitation
 	if tx.RowsAffected == 0 {
 		return GroupInvitationModel{}, storage.NoSuchGroupInvitationError
 	}
-	return ConvertToGroupInvitationModel(groupInvitation, true), tx.Error
+	return ConvertToGroupInvitationModel(groupInvitation), tx.Error
 }

--- a/storage/database/db_storages/user_storage.go
+++ b/storage/database/db_storages/user_storage.go
@@ -28,8 +28,6 @@ func (u *UserStorage) GetAll() ([]UserModel, error) {
 	// find all users in the database
 	// TODO: GetAllUsers should not return an error, if no users are found
 	tx := u.DB.
-		Preload("Groups.Owner").
-		Preload("Groups.Members").
 		Find(&users)
 	if tx.Error != nil {
 		return nil, tx.Error
@@ -42,8 +40,6 @@ func (u *UserStorage) GetAll() ([]UserModel, error) {
 func (u *UserStorage) GetByID(id uuid.UUID) (UserModel, error) {
 	var user User
 	tx := u.DB.Limit(1).
-		Preload("Groups.Owner").
-		Preload("Groups.Members").
 		Find(&user, "id = ?", id)
 	if tx.Error != nil {
 		if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
@@ -54,7 +50,7 @@ func (u *UserStorage) GetByID(id uuid.UUID) (UserModel, error) {
 	if tx.RowsAffected == 0 {
 		return UserModel{}, storage.NoSuchUserError
 	}
-	return ConvertToUserModel(user, true), nil
+	return ConvertToUserModel(user), nil
 }
 
 func (u *UserStorage) GetByEmail(email string) (UserModel, error) {
@@ -70,7 +66,7 @@ func (u *UserStorage) GetByEmail(email string) (UserModel, error) {
 	if tx.RowsAffected == 0 {
 		return UserModel{}, storage.NoSuchUserError
 	}
-	return ConvertToUserModel(user, true), nil
+	return ConvertToUserModel(user), nil
 }
 
 func (u *UserStorage) Create(user UserModel, passwordHash []byte) (UserModel, error) {
@@ -97,7 +93,7 @@ func (u *UserStorage) Create(user UserModel, passwordHash []byte) (UserModel, er
 		return nil
 	})
 
-	return ConvertToUserModel(item, true), err
+	return ConvertToUserModel(item), err
 }
 
 func (u *UserStorage) Update(user UserModel) (UserModel, error) {
@@ -105,7 +101,7 @@ func (u *UserStorage) Update(user UserModel) (UserModel, error) {
 
 	res := u.DB.Model(&User{}).Where("id = ?", user.ID).Updates(User{Username: user.Username}).First(&userEntity)
 	// TODO: error handling
-	return ConvertToUserModel(userEntity, false), res.Error
+	return ConvertToUserModel(userEntity), res.Error
 }
 
 func (u *UserStorage) GetCredentials(id uuid.UUID) ([]byte, error) {

--- a/storage/database/db_storages/user_storage_test.go
+++ b/storage/database/db_storages/user_storage_test.go
@@ -35,14 +35,11 @@ func TestGetByID(t *testing.T) {
 		want        model.UserModel
 	}{
 		{
-			// TODO: Use seed user instead of test user
 			name:    "Success",
 			userUID: TestUser.ID,
 			mock: func() {
 				userRows := sqlmock.NewRows([]string{"ID", "Email"}).AddRow(TestUser.ID, TestUser.Email)
 				dbMock.ExpectQuery(`SELECT (.+) FROM "users"`).WithArgs(TestUser.ID).WillReturnRows(userRows)
-				groupMemberRows := sqlmock.NewRows([]string{"ID", "OwnerUID"}).AddRow(uuid.New(), TestUser.ID)
-				dbMock.ExpectQuery(`SELECT (.+) FROM "group_members"`).WithArgs(TestUser.ID).WillReturnRows(groupMemberRows)
 			},
 			wantErr:     false,
 			expectedErr: nil,

--- a/storage/database/entity/bill.go
+++ b/storage/database/entity/bill.go
@@ -34,23 +34,17 @@ func CreateBillEntity(bill model.BillModel) Bill {
 	}
 }
 
-func ConvertToBillModel(bill Bill, isDetailed bool) model.BillModel {
+func ConvertToBillModel(bill Bill) model.BillModel {
 	items := make([]model.ItemModel, len(bill.Items))
-	owner := model.UserModel{}
-
-	if isDetailed {
-
-		for i, item := range bill.Items {
-			items[i] = ConvertToItemModel(item, true)
-		}
-		owner = ConvertToUserModel(bill.Owner, false)
+	for i, item := range bill.Items {
+		items[i] = ConvertToItemModel(item)
 	}
 
 	return model.BillModel{
 		ID:      bill.ID,
 		Name:    bill.Name,
 		Date:    bill.Date,
-		Owner:   owner,
+		Owner:   ConvertToUserModel(bill.Owner),
 		GroupID: bill.GroupID,
 		Items:   items,
 	}

--- a/storage/database/entity/group.go
+++ b/storage/database/entity/group.go
@@ -23,26 +23,20 @@ func CreateGroupEntity(group GroupModel) Group {
 	return Group{Base: Base{ID: group.ID}, OwnerUID: group.Owner.ID, Name: group.Name, Members: members}
 }
 
-func ConvertToGroupModel(group Group, isDetailed bool) GroupModel {
+func ConvertToGroupModel(group Group) GroupModel {
 	members := make([]UserModel, len(group.Members))
+	for i, member := range group.Members {
+		members[i] = ConvertToUserModel(*member)
+	}
 	bills := make([]BillModel, len(group.Bills))
-	owner := ConvertToUserModel(group.Owner, false)
-
-	if isDetailed {
-
-		for i, member := range group.Members {
-			members[i] = ConvertToUserModel(*member, false)
-		}
-
-		for i, bill := range group.Bills {
-			bills[i] = ConvertToBillModel(bill, false)
-		}
+	for i, bill := range group.Bills {
+		bills[i] = ConvertToBillModel(bill)
 	}
 
 	return GroupModel{
 		ID:      group.ID,
 		Name:    group.Name,
-		Owner:   owner,
+		Owner:   ConvertToUserModel(group.Owner),
 		Members: members,
 		Bills:   bills,
 	}
@@ -51,7 +45,7 @@ func ConvertToGroupModel(group Group, isDetailed bool) GroupModel {
 func ToGroupModelSlice(groups []Group) []GroupModel {
 	s := make([]GroupModel, len(groups))
 	for i, group := range groups {
-		s[i] = ConvertToGroupModel(group, true)
+		s[i] = ConvertToGroupModel(group)
 	}
 	return s
 }

--- a/storage/database/entity/invitation.go
+++ b/storage/database/entity/invitation.go
@@ -19,13 +19,10 @@ func CreateGroupInvitationEntity(groupInvitation GroupInvitationModel) GroupInvi
 	}
 }
 
-func ConvertToGroupInvitationModel(inv GroupInvitation, isDetailed bool) GroupInvitationModel {
-	group := GroupModel{}
-	if isDetailed {
-		group = ConvertToGroupModel(inv.Group, false)
-	}
+func ConvertToGroupInvitationModel(inv GroupInvitation) GroupInvitationModel {
+
 	return GroupInvitationModel{
 		ID:    inv.ID,
-		Group: group,
+		Group: ConvertToGroupModel(inv.Group),
 	}
 }

--- a/storage/database/entity/item.go
+++ b/storage/database/entity/item.go
@@ -22,15 +22,11 @@ func CreateItemEntity(item model.ItemModel) Item {
 	return Item{Base: Base{ID: item.ID}, Name: item.Name, Price: item.Price, BillID: item.BillID, Contributors: contributors}
 }
 
-func ConvertToItemModel(item Item, isDetailed bool) model.ItemModel {
+func ConvertToItemModel(item Item) model.ItemModel {
 	contributors := make([]model.UserModel, len(item.Contributors))
-
-	if isDetailed {
-		for i, contributor := range item.Contributors {
-			contributors[i] = ConvertToUserModel(*contributor, false)
-		}
+	for i, contributor := range item.Contributors {
+		contributors[i] = ConvertToUserModel(*contributor)
 	}
-
 	return model.ItemModel{
 		ID:           item.ID,
 		Name:         item.Name,

--- a/storage/database/entity/user.go
+++ b/storage/database/entity/user.go
@@ -19,28 +19,18 @@ func CreateUserEntity(user model.UserModel) User {
 	}
 }
 
-func ConvertToUserModel(user User, isDetailed bool) model.UserModel {
-
-	groupModels := make([]model.GroupModel, len(user.Groups))
-
-	if isDetailed {
-		for i, group := range user.Groups {
-			groupModels[i] = ConvertToGroupModel(*group, false)
-		}
-	}
-
+func ConvertToUserModel(user User) model.UserModel {
 	return model.UserModel{
 		ID:       user.ID,
 		Email:    user.Email,
 		Username: user.Username,
-		Groups:   groupModels,
 	}
 }
 
 func ToUserModelSlice(users []User) []model.UserModel {
 	s := make([]model.UserModel, len(users))
 	for i, user := range users {
-		s[i] = ConvertToUserModel(user, true)
+		s[i] = ConvertToUserModel(user)
 	}
 	return s
 }


### PR DESCRIPTION
I have removed group and invitation from the user model and dtos. As a result we do not classify during model conversion whether we need a detailed description or not.

Closes #127 