### PR TITLE
159: Randomize profile image file name

### DIFF
--- a/domain/util/filestorage.go
+++ b/domain/util/filestorage.go
@@ -5,18 +5,38 @@ import (
 	"github.com/google/uuid"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func StoreFile(file []byte, userID uuid.UUID) (string, error) {
-	// create file name
-	fileName := userID.String() + ".gif"
+	// create file name with random string appended
+	randomString := uuid.New().String()
+	fileName := userID.String() + "_" + randomString + ".gif"
 	// save file
 	filePath := filepath.Join("./uploads/profileImages", fileName)
+
+	// Delete existing files with the same userID prefix
+	if err := deleteFilesWithPrefix("./uploads/profileImages", userID.String()); err != nil {
+		return "", err
+	}
+
 	err := os.WriteFile(filePath, file, 0644)
 	if err != nil {
 		return "", ErrStoreFile
 	}
 	return filePath, nil
+}
+
+func deleteFilesWithPrefix(dirPath string, prefix string) error {
+	return filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasPrefix(info.Name(), prefix) {
+			return os.Remove(path)
+		}
+		return nil
+	})
 }
 
 var ErrStoreFile = errors.New("cannot store file")


### PR DESCRIPTION
I encountered a problem in frontend while updating the profile image of an user due to the way Flutter handles network images. It caches the images based on the URL. Since it stays the same in the current backend implementation, the image doesn't reload after an update. Manually deactivating the cache has some mean side-effects.

Therefore the easiest and best solution I found was to randomize the file name, so that the path to the image also changes. ```deleteFilesWithPrefix``` does the cleanup.