### PR TITLE
155: Revisit clear debts feature

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -476,6 +476,37 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
+                            "$ref": "#/definitions/dto.GeneralResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/group/{id}/transaction": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create Group Transaction \u0026 Clear Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
                             "allOf": [
                                 {
                                     "$ref": "#/definitions/dto.GeneralResponse"
@@ -484,7 +515,7 @@ const docTemplate = `{
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.GroupDeletionOutput"
+                                            "$ref": "#/definitions/dto.GroupTransactionOutput"
                                         }
                                     }
                                 }
@@ -840,17 +871,6 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GroupDeletionOutput": {
-            "type": "object",
-            "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/util.Transaction"
-                    }
-                }
-            }
-        },
         "dto.GroupDetailedOutput": {
             "type": "object",
             "properties": {
@@ -899,6 +919,29 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.GroupTransactionOutput": {
+            "type": "object",
+            "properties": {
+                "groupId": {
+                    "type": "string"
+                },
+                "groupName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TransactionOutput"
+                    }
+                }
+            }
+        },
         "dto.ItemInput": {
             "type": "object",
             "properties": {
@@ -942,6 +985,20 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.TransactionOutput": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "creditor": {
+                    "$ref": "#/definitions/dto.UserCoreOutput"
+                },
+                "debtor": {
+                    "$ref": "#/definitions/dto.UserCoreOutput"
+                }
+            }
+        },
         "dto.UserCoreOutput": {
             "type": "object",
             "properties": {
@@ -966,20 +1023,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "util.Transaction": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "number"
-                },
-                "creditorID": {
-                    "type": "string"
-                },
-                "debtorID": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -371,11 +371,11 @@ const docTemplate = `{
                 "tags": [
                     "Group"
                 ],
-                "summary": "Get Group Transactions by User",
+                "summary": "Get Group Transactions For All Groups",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "User ID",
+                        "description": "User ID - Retrieve transactions for groups where user is a member",
                         "name": "userId",
                         "in": "query",
                         "required": true

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -360,6 +360,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/group/transaction": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get Group Transactions by User",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.GeneralResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/dto.GroupTransactionOutput"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/group/{id}": {
             "get": {
                 "consumes": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -968,6 +968,9 @@ const docTemplate = `{
         "dto.GroupTransactionOutput": {
             "type": "object",
             "properties": {
+                "date": {
+                    "type": "string"
+                },
                 "groupId": {
                     "type": "string"
                 },
@@ -975,9 +978,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
-                    "type": "string"
-                },
-                "name": {
                     "type": "string"
                 },
                 "transactions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -353,6 +353,52 @@
                 }
             }
         },
+        "/api/group/transaction": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Get Group Transactions by User",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "userId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/dto.GeneralResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/dto.GroupTransactionOutput"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/group/{id}": {
             "get": {
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -469,6 +469,37 @@
                     "200": {
                         "description": "OK",
                         "schema": {
+                            "$ref": "#/definitions/dto.GeneralResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/group/{id}/transaction": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Group"
+                ],
+                "summary": "Create Group Transaction \u0026 Clear Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
                             "allOf": [
                                 {
                                     "$ref": "#/definitions/dto.GeneralResponse"
@@ -477,7 +508,7 @@
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.GroupDeletionOutput"
+                                            "$ref": "#/definitions/dto.GroupTransactionOutput"
                                         }
                                     }
                                 }
@@ -833,17 +864,6 @@
                 }
             }
         },
-        "dto.GroupDeletionOutput": {
-            "type": "object",
-            "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/util.Transaction"
-                    }
-                }
-            }
-        },
         "dto.GroupDetailedOutput": {
             "type": "object",
             "properties": {
@@ -892,6 +912,29 @@
                 }
             }
         },
+        "dto.GroupTransactionOutput": {
+            "type": "object",
+            "properties": {
+                "groupId": {
+                    "type": "string"
+                },
+                "groupName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TransactionOutput"
+                    }
+                }
+            }
+        },
         "dto.ItemInput": {
             "type": "object",
             "properties": {
@@ -935,6 +978,20 @@
                 }
             }
         },
+        "dto.TransactionOutput": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number"
+                },
+                "creditor": {
+                    "$ref": "#/definitions/dto.UserCoreOutput"
+                },
+                "debtor": {
+                    "$ref": "#/definitions/dto.UserCoreOutput"
+                }
+            }
+        },
         "dto.UserCoreOutput": {
             "type": "object",
             "properties": {
@@ -959,20 +1016,6 @@
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "util.Transaction": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "number"
-                },
-                "creditorID": {
-                    "type": "string"
-                },
-                "debtorID": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -961,6 +961,9 @@
         "dto.GroupTransactionOutput": {
             "type": "object",
             "properties": {
+                "date": {
+                    "type": "string"
+                },
                 "groupId": {
                     "type": "string"
                 },
@@ -968,9 +971,6 @@
                     "type": "string"
                 },
                 "id": {
-                    "type": "string"
-                },
-                "name": {
                     "type": "string"
                 },
                 "transactions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -364,11 +364,11 @@
                 "tags": [
                     "Group"
                 ],
-                "summary": "Get Group Transactions by User",
+                "summary": "Get Group Transactions For All Groups",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "User ID",
+                        "description": "User ID - Retrieve transactions for groups where user is a member",
                         "name": "userId",
                         "in": "query",
                         "required": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -475,7 +475,7 @@ paths:
       consumes:
       - application/json
       parameters:
-      - description: User ID
+      - description: User ID - Retrieve transactions for groups where user is a member
         in: query
         name: userId
         required: true
@@ -494,7 +494,7 @@ paths:
                     $ref: '#/definitions/dto.GroupTransactionOutput'
                   type: array
               type: object
-      summary: Get Group Transactions by User
+      summary: Get Group Transactions For All Groups
       tags:
       - Group
   /api/user:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -90,13 +90,13 @@ definitions:
     type: object
   dto.GroupTransactionOutput:
     properties:
+      date:
+        type: string
       groupId:
         type: string
       groupName:
         type: string
       id:
-        type: string
-      name:
         type: string
       transactions:
         items:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -56,13 +56,6 @@ definitions:
       message:
         type: string
     type: object
-  dto.GroupDeletionOutput:
-    properties:
-      transactions:
-        items:
-          $ref: '#/definitions/util.Transaction'
-        type: array
-    type: object
   dto.GroupDetailedOutput:
     properties:
       balance:
@@ -95,6 +88,21 @@ definitions:
       ownerID:
         type: string
     type: object
+  dto.GroupTransactionOutput:
+    properties:
+      groupId:
+        type: string
+      groupName:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      transactions:
+        items:
+          $ref: '#/definitions/dto.TransactionOutput'
+        type: array
+    type: object
   dto.ItemInput:
     properties:
       billId:
@@ -123,6 +131,15 @@ definitions:
       price:
         type: number
     type: object
+  dto.TransactionOutput:
+    properties:
+      amount:
+        type: number
+      creditor:
+        $ref: '#/definitions/dto.UserCoreOutput'
+      debtor:
+        $ref: '#/definitions/dto.UserCoreOutput'
+    type: object
   dto.UserCoreOutput:
     properties:
       email:
@@ -139,15 +156,6 @@ definitions:
       email:
         type: string
       password:
-        type: string
-    type: object
-  util.Transaction:
-    properties:
-      amount:
-        type: number
-      creditorID:
-        type: string
-      debtorID:
         type: string
     type: object
 host: localhost:8080
@@ -359,12 +367,7 @@ paths:
         "200":
           description: OK
           schema:
-            allOf:
-            - $ref: '#/definitions/dto.GeneralResponse'
-            - properties:
-                data:
-                  $ref: '#/definitions/dto.GroupDeletionOutput'
-              type: object
+            $ref: '#/definitions/dto.GeneralResponse'
       summary: Delete Group
       tags:
       - Group
@@ -420,6 +423,31 @@ paths:
                   $ref: '#/definitions/dto.GroupDetailedOutput'
               type: object
       summary: Update Group
+      tags:
+      - Group
+  /api/group/{id}/transaction:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/dto.GeneralResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/dto.GroupTransactionOutput'
+              type: object
+      summary: Create Group Transaction & Clear Group
       tags:
       - Group
   /api/group/invitation/{id}/accept:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -470,6 +470,33 @@ paths:
       summary: Accept Group Invitation
       tags:
       - Group
+  /api/group/transaction:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: User ID
+        in: query
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/dto.GeneralResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/dto.GroupTransactionOutput'
+                  type: array
+              type: object
+      summary: Get Group Transactions by User
+      tags:
+      - Group
   /api/user:
     get:
       consumes:

--- a/domain/converter/converter.go
+++ b/domain/converter/converter.go
@@ -77,6 +77,41 @@ func ToGroupDetailedDTO(g model.Group) dto.GroupDetailedOutput {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// GROUP TRANSACTION
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func ToGroupTransactionDTO(g model.GroupTransaction) dto.GroupTransactionOutput {
+
+	return dto.GroupTransactionOutput{
+		ID:           g.ID,
+		Date:         g.Date,
+		GroupID:      g.GroupID,
+		GroupName:    g.GroupName,
+		Transactions: ToTransactionDTOs(g.Transactions),
+	}
+}
+
+func ToTransactionDTOs(transactions []model.Transaction) []dto.TransactionOutput {
+	transactionsDTO := make([]dto.TransactionOutput, len(transactions))
+
+	for i, transaction := range transactions {
+		transactionsDTO[i] = ToTransactionDTO(transaction)
+	}
+	return transactionsDTO
+}
+
+func ToTransactionDTO(t model.Transaction) dto.TransactionOutput {
+	debtor := ToUserCoreDTO(&t.Debtor)
+	creditor := ToUserCoreDTO(&t.Creditor)
+
+	return dto.TransactionOutput{
+		Debtor:   debtor,
+		Creditor: creditor,
+		Amount:   t.Amount,
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // USER
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/domain/model/group.go
+++ b/domain/model/group.go
@@ -32,6 +32,7 @@ func CreateGroup(id uuid.UUID, group dto.GroupInput, members []uuid.UUID) Group 
 	}
 }
 
+// CalculateBalance Calculate balance for each member in the group
 func (group *Group) CalculateBalance() map[uuid.UUID]float64 {
 	balance := make(map[uuid.UUID]float64)
 	// init balance for all members

--- a/domain/model/group_transaction.go
+++ b/domain/model/group_transaction.go
@@ -1,14 +1,24 @@
-package util
+package model
 
 import (
 	"github.com/google/uuid"
 	"math"
+	"time"
 )
 
+type GroupTransaction struct {
+	ID           uuid.UUID
+	Date         time.Time
+	GroupID      uuid.UUID
+	GroupName    string
+	Transactions []Transaction
+}
+
 type Transaction struct {
-	DebtorID   uuid.UUID
-	CreditorID uuid.UUID
-	Amount     float64
+	ID       uuid.UUID
+	Debtor   User
+	Creditor User
+	Amount   float64
 }
 
 type Amount struct {
@@ -18,9 +28,10 @@ type Amount struct {
 
 func CreateTransaction(debtorID uuid.UUID, creditorID uuid.UUID, amount float64) Transaction {
 	return Transaction{
-		DebtorID:   debtorID,
-		CreditorID: creditorID,
-		Amount:     amount,
+		ID:       uuid.New(),
+		Debtor:   User{ID: debtorID},
+		Creditor: User{ID: creditorID},
+		Amount:   amount,
 	}
 }
 

--- a/domain/model/group_transaction_test.go
+++ b/domain/model/group_transaction_test.go
@@ -1,4 +1,4 @@
-package util
+package model
 
 import (
 	"github.com/google/uuid"
@@ -60,8 +60,8 @@ func TestSplitGroupBalance(t *testing.T) {
 			splits := ProduceTransactionsFromBalance(testcase.balance)
 			inputBalance := testcase.balance
 			for _, splitEntry := range splits {
-				inputBalance[splitEntry.DebtorID] += splitEntry.Amount
-				inputBalance[splitEntry.CreditorID] -= splitEntry.Amount
+				inputBalance[splitEntry.Debtor.ID] += splitEntry.Amount
+				inputBalance[splitEntry.Creditor.ID] -= splitEntry.Amount
 				// check if no split contains a value of 0
 				assert.NotEqualf(t, 0.0, splitEntry.Amount, "Split must not contain a value of 0")
 			}

--- a/domain/service/group_service_inf.go
+++ b/domain/service/group_service_inf.go
@@ -22,10 +22,14 @@ type IGroupService interface {
 	// *Authorization required: requesterID == id (for param: userID)
 	GetAll(requesterID uuid.UUID, userID uuid.UUID, invitationID uuid.UUID) ([]dto.GroupDetailedOutput, error)
 
-	// Delete deletes the group with the given id. Returns the transactions needed to clear the group balance.
+	// Delete deletes the group with the given id.
 	// *Authorization required: requester == group.Owner
-	Delete(requesterID uuid.UUID, id uuid.UUID) (dto.GroupDeletionOutput, error)
+	Delete(requesterID uuid.UUID, id uuid.UUID) error
 
 	// AcceptGroupInvitation accepts the invitation and adds user to the group.
 	AcceptGroupInvitation(invitationID uuid.UUID, userID uuid.UUID) error
+
+	// CreateGroupTransaction creates a new group transaction and removes all bills from the group.
+	// *Authorization required: requester == group.Owner
+	CreateGroupTransaction(requesterID uuid.UUID, groupID uuid.UUID) (dto.GroupTransactionOutput, error)
 }

--- a/domain/service/group_service_inf.go
+++ b/domain/service/group_service_inf.go
@@ -32,4 +32,8 @@ type IGroupService interface {
 	// CreateGroupTransaction creates a new group transaction and removes all bills from the group.
 	// *Authorization required: requester == group.Owner
 	CreateGroupTransaction(requesterID uuid.UUID, groupID uuid.UUID) (dto.GroupTransactionOutput, error)
+
+	// GetAllGroupTransactions returns all transactions for groups in which the user is a member.
+	// *Authorization required: requesterID == id (for param: userID)
+	GetAllGroupTransactions(requesterID uuid.UUID, userID uuid.UUID) ([]dto.GroupTransactionOutput, error)
 }

--- a/domain/service/impl/group_service.go
+++ b/domain/service/impl/group_service.go
@@ -146,3 +146,21 @@ func (g *GroupService) CreateGroupTransaction(requesterID uuid.UUID, groupID uui
 
 	return converter.ToGroupTransactionDTO(groupTransaction), nil
 }
+
+func (g *GroupService) GetAllGroupTransactions(requesterID uuid.UUID, userID uuid.UUID) ([]dto.GroupTransactionOutput, error) {
+	// Authorization
+	if userID != uuid.Nil && requesterID != userID {
+		return nil, ErrNotAuthorized
+	}
+	groupTransactions, err := g.groupStorage.GetAllGroupTransactions(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	var groupTransactionsDTO []dto.GroupTransactionOutput
+	for _, groupTransaction := range groupTransactions {
+		groupTransactionsDTO = append(groupTransactionsDTO, converter.ToGroupTransactionDTO(groupTransaction))
+	}
+
+	return groupTransactionsDTO, nil
+}

--- a/domain/service/mocks/group_service_mock.go
+++ b/domain/service/mocks/group_service_mock.go
@@ -12,7 +12,8 @@ var (
 	MockGroupGetByID               func(requesterID uuid.UUID, id uuid.UUID) (dto.GroupDetailedOutput, error)
 	MockGroupGetAll                func(requesterID uuid.UUID, userID uuid.UUID, invitationID uuid.UUID) ([]dto.GroupDetailedOutput, error)
 	MockGroupAcceptGroupInvitation func(invitationID uuid.UUID, userID uuid.UUID) error
-	MockGroupDelete                func(requesterID uuid.UUID, id uuid.UUID) (dto.GroupDeletionOutput, error)
+	MockGroupDelete                func(requesterID uuid.UUID, id uuid.UUID) error
+	MockGroupTransactionCreate     func(requesterID uuid.UUID, id uuid.UUID) (dto.GroupTransactionOutput, error)
 )
 
 func NewGroupServiceMock() service.IGroupService {
@@ -38,10 +39,14 @@ func (g GroupServiceMock) GetAll(requesterID uuid.UUID, userID uuid.UUID, invita
 	return MockGroupGetAll(requesterID, userID, invitationID)
 }
 
-func (g GroupServiceMock) Delete(requesterID uuid.UUID, id uuid.UUID) (dto.GroupDeletionOutput, error) {
+func (g GroupServiceMock) Delete(requesterID uuid.UUID, id uuid.UUID) error {
 	return MockGroupDelete(requesterID, id)
 }
 
 func (g GroupServiceMock) AcceptGroupInvitation(invitationID uuid.UUID, userID uuid.UUID) error {
 	return MockGroupAcceptGroupInvitation(invitationID, userID)
+}
+
+func (g GroupServiceMock) CreateGroupTransaction(requesterID uuid.UUID, groupID uuid.UUID) (dto.GroupTransactionOutput, error) {
+	return MockGroupTransactionCreate(requesterID, groupID)
 }

--- a/domain/service/mocks/group_service_mock.go
+++ b/domain/service/mocks/group_service_mock.go
@@ -14,6 +14,7 @@ var (
 	MockGroupAcceptGroupInvitation func(invitationID uuid.UUID, userID uuid.UUID) error
 	MockGroupDelete                func(requesterID uuid.UUID, id uuid.UUID) error
 	MockGroupTransactionCreate     func(requesterID uuid.UUID, id uuid.UUID) (dto.GroupTransactionOutput, error)
+	MockGroupTransactionGetAll     func(requesterID uuid.UUID, userID uuid.UUID) ([]dto.GroupTransactionOutput, error)
 )
 
 func NewGroupServiceMock() service.IGroupService {
@@ -49,4 +50,8 @@ func (g GroupServiceMock) AcceptGroupInvitation(invitationID uuid.UUID, userID u
 
 func (g GroupServiceMock) CreateGroupTransaction(requesterID uuid.UUID, groupID uuid.UUID) (dto.GroupTransactionOutput, error) {
 	return MockGroupTransactionCreate(requesterID, groupID)
+}
+
+func (g GroupServiceMock) GetAllGroupTransactions(requesterID uuid.UUID, userID uuid.UUID) ([]dto.GroupTransactionOutput, error) {
+	return MockGroupTransactionGetAll(requesterID, userID)
 }

--- a/presentation/dto/group.go
+++ b/presentation/dto/group.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"errors"
 	"github.com/google/uuid"
-	"split-the-bill-server/domain/util"
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -23,10 +22,6 @@ type GroupDetailedOutput struct {
 	Bills        []BillDetailedOutput  `json:"bills"`
 	Balance      map[uuid.UUID]float64 `json:"balance,omitempty"`      // include balance only if balance is set
 	InvitationID uuid.UUID             `json:"invitationID,omitempty"` // include invitationID only if invitationID is set
-}
-
-type GroupDeletionOutput struct {
-	Transactions []util.Transaction `json:"transactions"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/presentation/dto/group_transaction.go
+++ b/presentation/dto/group_transaction.go
@@ -1,0 +1,24 @@
+package dto
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Input/Output DTOs
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+type GroupTransactionOutput struct {
+	ID           uuid.UUID           `json:"id"`
+	Date         time.Time           `json:"name"`
+	GroupID      uuid.UUID           `json:"groupId"`
+	GroupName    string              `json:"groupName"`
+	Transactions []TransactionOutput `json:"transactions"`
+}
+
+type TransactionOutput struct {
+	Debtor   UserCoreOutput `json:"debtor"`
+	Creditor UserCoreOutput `json:"creditor"`
+	Amount   float64        `json:"amount"`
+}

--- a/presentation/dto/group_transaction.go
+++ b/presentation/dto/group_transaction.go
@@ -11,7 +11,7 @@ import (
 
 type GroupTransactionOutput struct {
 	ID           uuid.UUID           `json:"id"`
-	Date         time.Time           `json:"name"`
+	Date         time.Time           `json:"date"`
 	GroupID      uuid.UUID           `json:"groupId"`
 	GroupName    string              `json:"groupName"`
 	Transactions []TransactionOutput `json:"transactions"`

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -183,7 +183,7 @@ func (h GroupHandler) GetAll(c *fiber.Ctx) error {
 //	@Accept		json
 //	@Produce	json
 //	@Param		id	path		string	true	"Group ID"
-//	@Success	200	{object}	dto.GeneralResponse{data=dto.GroupDeletionOutput}
+//	@Success	200	{object}	dto.GeneralResponse
 //	@Router		/api/group/{id} [delete]
 func (h GroupHandler) Delete(c *fiber.Ctx) error {
 	// parse parameter
@@ -198,14 +198,14 @@ func (h GroupHandler) Delete(c *fiber.Ctx) error {
 	// get requesterID from context
 	requesterID := c.Locals(middleware.UserKey).(uuid.UUID)
 	// delete group
-	transaction, err := h.groupService.Delete(requesterID, uid)
+	err = h.groupService.Delete(requesterID, uid)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotAuthorized) {
 			return Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgGroupDelete, err))
 		}
 		return Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgGroupDelete, err))
 	}
-	return Success(c, fiber.StatusOK, SuccessMsgGroupDelete, transaction)
+	return Success(c, fiber.StatusOK, SuccessMsgGroupDelete, nil)
 }
 
 // AcceptInvitation accepts a group invitation.
@@ -239,4 +239,38 @@ func (h GroupHandler) AcceptInvitation(c *fiber.Ctx) error {
 	}
 
 	return Success(c, fiber.StatusOK, SuccessMsgInvitationHandled, nil)
+}
+
+// CreateGroupTransaction creates a group transaction and clears the group
+//
+//	@Summary	Create Group Transaction & Clear Group
+//	@Tags		Group
+//	@Accept		json
+//	@Produce	json
+//	@Param		id	path		string	true	"Group ID"
+//	@Success	200	{object}	dto.GeneralResponse{data=dto.GroupTransactionOutput}
+//	@Router		/api/group/{id}/transaction [post]
+func (h GroupHandler) CreateGroupTransaction(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if id == "" {
+		return Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParameterRequired, "id"))
+	}
+	groupID, err := uuid.Parse(id)
+	if err != nil {
+		return Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParseUUID, id, err))
+	}
+
+	// get authenticated requesterID from context
+	requesterID := c.Locals(middleware.UserKey).(uuid.UUID)
+
+	transaction, err := h.groupService.CreateGroupTransaction(requesterID, groupID)
+
+	if err != nil {
+		if errors.Is(err, domain.ErrNotAuthorized) {
+			return Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgGroupTransactionCreate, err))
+		}
+		return Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgGroupTransactionCreate, err))
+	}
+
+	return Success(c, fiber.StatusCreated, SuccessMsgGroupTransactionCreate, transaction)
 }

--- a/presentation/handler/group_handler.go
+++ b/presentation/handler/group_handler.go
@@ -277,11 +277,11 @@ func (h GroupHandler) CreateGroupTransaction(c *fiber.Ctx) error {
 
 // GetAllGroupTransactions returns all group transactions with applied filter.
 //
-//	@Summary	Get Group Transactions by User
+//	@Summary	Get Group Transactions For All Groups
 //	@Tags		Group
 //	@Accept		json
 //	@Produce	json
-//	@Param		userId	query		string	true	"User ID"
+//	@Param		userId	query		string	true	"User ID - Retrieve transactions for groups where user is a member"
 //	@Success	200		{object}	dto.GeneralResponse{data=[]dto.GroupTransactionOutput}
 //	@Router		/api/group/transaction [get]
 func (h GroupHandler) GetAllGroupTransactions(c *fiber.Ctx) error {

--- a/presentation/handler/messages.go
+++ b/presentation/handler/messages.go
@@ -21,6 +21,12 @@ const (
 	SuccessMsgGroupUpdate = "Group updated"
 	SuccessMsgGroupDelete = "Group deleted"
 
+	// Group transaction - ERROR
+	ErrMsgGroupTransactionCreate = "Could not create group transaction: %v"
+
+	// Group transaction - SUCCESS
+	SuccessMsgGroupTransactionCreate = "Group transaction created"
+
 	// Bill - ERROR
 	ErrMsgBillParse    = "Could not parse bill: %v"
 	ErrMsgBillCreate   = "Could not create bill: %v"
@@ -35,19 +41,6 @@ const (
 	SuccessMsgBillUpdate = "Bill updated"
 	SuccessMsgBillGetAll = "Bills found"
 	SuccessMsgBillDelete = "Bill deleted"
-
-	// Item - ERROR
-	ErrMsgItemParse    = "Could not parse item: %v"
-	ErrMsgItemCreate   = "Could not create item: %v"
-	ErrMsgItemUpdate   = "Could not update item: %v"
-	ErrMsgItemNotFound = "Item not found: %v"
-	ErrMsgItemDelete   = "Could not delete item: %v"
-
-	// Item - SUCCESS
-	SuccessMsgItemCreate = "Item created"
-	SuccessMsgItemUpdate = "Item updated"
-	SuccessMsgItemFound  = "Item found"
-	SuccessMsgItemDelete = "Item deleted"
 
 	// User - ERROR
 	ErrMsgUserParse            = "Could not parse user: %v"
@@ -72,7 +65,6 @@ const (
 
 	// Invitation - ERROR
 	ErrMsgInvitationHandle = "Could not handle invitation: %v"
-	ErrMsgInvitationParse  = "Could not parse invitation: %v"
 
 	// Invitation - SUCCESS
 	SuccessMsgInvitationHandled = "Invitation handled"

--- a/presentation/handler/messages.go
+++ b/presentation/handler/messages.go
@@ -23,9 +23,11 @@ const (
 
 	// Group transaction - ERROR
 	ErrMsgGroupTransactionCreate = "Could not create group transaction: %v"
+	ErrMsgGetUserTransactions    = "Could not get group transaction: %v"
 
 	// Group transaction - SUCCESS
 	SuccessMsgGroupTransactionCreate = "Group transaction created"
+	SuccessMsgGroupTransactionFound  = "Group transaction found"
 
 	// Bill - ERROR
 	ErrMsgBillParse    = "Could not parse bill: %v"

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -57,11 +57,12 @@ func SetupRoutes(app *fiber.App, u UserHandler, g GroupHandler, b BillHandler, a
 	// group routes
 	groupRoute := api.Group("/group")
 	// routes
-	groupRoute.Post("/", a.Authenticate, g.Create)
-	groupRoute.Put("/:id", a.Authenticate, g.Update)
-	groupRoute.Get("/:id", a.Authenticate, g.GetByID)
-	groupRoute.Get("/", a.Authenticate, g.GetAll)
-	groupRoute.Delete("/:id", a.Authenticate, g.Delete)
 	groupRoute.Post("/invitation/:id/accept", a.Authenticate, g.AcceptInvitation)
 	groupRoute.Post("/:id/transaction/", a.Authenticate, g.CreateGroupTransaction)
+	groupRoute.Get("/transaction/", a.Authenticate, g.GetAllGroupTransactions)
+	groupRoute.Put("/:id", a.Authenticate, g.Update)
+	groupRoute.Get("/:id", a.Authenticate, g.GetByID)
+	groupRoute.Delete("/:id", a.Authenticate, g.Delete)
+	groupRoute.Post("/", a.Authenticate, g.Create)
+	groupRoute.Get("/", a.Authenticate, g.GetAll)
 }

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -63,4 +63,5 @@ func SetupRoutes(app *fiber.App, u UserHandler, g GroupHandler, b BillHandler, a
 	groupRoute.Get("/", a.Authenticate, g.GetAll)
 	groupRoute.Delete("/:id", a.Authenticate, g.Delete)
 	groupRoute.Post("/invitation/:id/accept", a.Authenticate, g.AcceptInvitation)
+	groupRoute.Post("/:id/transaction/", a.Authenticate, g.CreateGroupTransaction)
 }

--- a/storage/database/converter/converter.go
+++ b/storage/database/converter/converter.go
@@ -139,6 +139,55 @@ func ToGroupModels(groups []entity.Group) []model.Group {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// GROUP TRANSACTION
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func ToGroupTransactionEntity(g model.GroupTransaction) entity.GroupTransaction {
+	// convert transactions
+	var transactions []entity.Transaction
+	for _, transaction := range g.Transactions {
+		transactions = append(transactions, ToTransactionEntity(transaction))
+	}
+	return entity.GroupTransaction{
+		Base:         entity.Base{ID: g.ID},
+		Date:         g.Date,
+		GroupID:      g.GroupID,
+		Transactions: transactions,
+	}
+}
+
+func ToTransactionEntity(t model.Transaction) entity.Transaction {
+	return entity.Transaction{
+		Base:       entity.Base{ID: t.ID},
+		DebtorID:   t.Debtor.ID,
+		CreditorID: t.Creditor.ID,
+		Amount:     t.Amount,
+	}
+}
+
+func ToGroupTransactionModel(g entity.GroupTransaction) model.GroupTransaction {
+	transactions := make([]model.Transaction, len(g.Transactions))
+	for i, transaction := range g.Transactions {
+		transactions[i] = ToTransactionModel(transaction)
+	}
+	return model.GroupTransaction{
+		ID:           g.ID,
+		Date:         g.Date,
+		GroupID:      g.Group.ID,
+		GroupName:    g.Group.Name,
+		Transactions: transactions,
+	}
+}
+
+func ToTransactionModel(t entity.Transaction) model.Transaction {
+	return model.Transaction{
+		Debtor:   ToUserModel(t.Debtor),
+		Creditor: ToUserModel(t.Creditor),
+		Amount:   t.Amount,
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ITEM
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/storage/database/converter/converter.go
+++ b/storage/database/converter/converter.go
@@ -179,6 +179,14 @@ func ToGroupTransactionModel(g entity.GroupTransaction) model.GroupTransaction {
 	}
 }
 
+func ToGroupTransactionModels(g []entity.GroupTransaction) []model.GroupTransaction {
+	s := make([]model.GroupTransaction, len(g))
+	for i, groupTransaction := range g {
+		s[i] = ToGroupTransactionModel(groupTransaction)
+	}
+	return s
+}
+
 func ToTransactionModel(t entity.Transaction) model.Transaction {
 	return model.Transaction{
 		Debtor:   ToUserModel(t.Debtor),

--- a/storage/database/database.go
+++ b/storage/database/database.go
@@ -45,7 +45,7 @@ func (d *Database) Connect() error {
 	db.Logger = logger.Default.LogMode(logger.Info)
 	log.Println("running migrations")
 	// migrate models to database
-	err = db.AutoMigrate(&User{}, &AuthCookie{}, &Credentials{}, &Group{}, &GroupInvitation{}, &Bill{}, &Item{})
+	err = db.AutoMigrate(&User{}, &AuthCookie{}, &Credentials{}, &Group{}, &GroupInvitation{}, &Bill{}, &Item{}, &GroupTransaction{}, &Transaction{})
 	if err != nil {
 		return err
 	}

--- a/storage/database/db_storages/group_storage.go
+++ b/storage/database/db_storages/group_storage.go
@@ -166,3 +166,20 @@ func (g *GroupStorage) CreateGroupTransaction(transaction model.GroupTransaction
 
 	return converter.ToGroupTransactionModel(groupTransactionEntity), err
 }
+
+func (g *GroupStorage) GetAllGroupTransactions(userID uuid.UUID) ([]model.GroupTransaction, error) {
+	var groupTransactions []entity.GroupTransaction
+
+	tx := g.DB.
+		Preload(clause.Associations).
+		Preload("Transactions.Debtor").
+		Preload("Transactions.Creditor").
+		Where("group_id IN (SELECT group_id FROM group_members WHERE user_id = ?)", userID).
+		Find(&groupTransactions)
+
+	if tx.Error != nil {
+		return nil, tx.Error
+	}
+
+	return converter.ToGroupTransactionModels(groupTransactions), nil
+}

--- a/storage/database/entity/group_transaction.go
+++ b/storage/database/entity/group_transaction.go
@@ -1,0 +1,24 @@
+package entity
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+type GroupTransaction struct {
+	Base
+	Date         time.Time     `gorm:"not null"`
+	GroupID      uuid.UUID     `gorm:"type:uuid"` // group transaction belongs to a group
+	Group        Group         `gorm:"foreignKey:GroupID"`
+	Transactions []Transaction `gorm:"foreignKey:GroupTransactionID"`
+}
+
+type Transaction struct {
+	Base
+	DebtorID           uuid.UUID // transaction belongs to a debtor
+	Debtor             User
+	CreditorID         uuid.UUID // transaction belongs to a creditor
+	Creditor           User
+	Amount             float64
+	GroupTransactionID uuid.UUID
+}

--- a/storage/ephemeral/eph_storages/group_storage.go
+++ b/storage/ephemeral/eph_storages/group_storage.go
@@ -71,3 +71,8 @@ func (g *GroupStorage) DeleteGroup(id uuid.UUID) error {
 	//TODO implement me
 	panic("implement me")
 }
+
+func (g *GroupStorage) CreateGroupTransaction(transaction model.GroupTransaction) (model.GroupTransaction, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/storage/ephemeral/eph_storages/group_storage.go
+++ b/storage/ephemeral/eph_storages/group_storage.go
@@ -76,3 +76,8 @@ func (g *GroupStorage) CreateGroupTransaction(transaction model.GroupTransaction
 	//TODO implement me
 	panic("implement me")
 }
+
+func (g *GroupStorage) GetAllGroupTransactions(userID uuid.UUID) ([]model.GroupTransaction, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/storage/group_storage_inf.go
+++ b/storage/group_storage_inf.go
@@ -23,4 +23,7 @@ type IGroupStorage interface {
 
 	// AcceptGroupInvitation adds the associated user to a group
 	AcceptGroupInvitation(invitationID UUID, userID UUID) error
+
+	// CreateGroupTransaction creates a new group transaction and clears the group
+	CreateGroupTransaction(transaction model.GroupTransaction) (model.GroupTransaction, error)
 }

--- a/storage/group_storage_inf.go
+++ b/storage/group_storage_inf.go
@@ -26,4 +26,7 @@ type IGroupStorage interface {
 
 	// CreateGroupTransaction creates a new group transaction and clears the group
 	CreateGroupTransaction(transaction model.GroupTransaction) (model.GroupTransaction, error)
+
+	// GetAllGroupTransactions returns all transactions for groups where user is a member
+	GetAllGroupTransactions(userID UUID) ([]model.GroupTransaction, error)
 }

--- a/storage/mocks/group_storage_mock.go
+++ b/storage/mocks/group_storage_mock.go
@@ -13,6 +13,7 @@ var (
 	MockGroupGetGroups             func(uuid.UUID, uuid.UUID) ([]model.Group, error)
 	MockGroupDeleteGroup           func(uuid.UUID) error
 	MockGroupAcceptGroupInvitation func(uuid.UUID, uuid.UUID) error
+	MockCreateGroupTransaction     func(transaction model.GroupTransaction) (model.GroupTransaction, error)
 )
 
 func NewGroupStorageMock() storage.IGroupStorage {
@@ -44,4 +45,8 @@ func (g GroupStorageMock) DeleteGroup(id uuid.UUID) error {
 
 func (g GroupStorageMock) AcceptGroupInvitation(invitationID uuid.UUID, userID uuid.UUID) error {
 	return MockGroupAcceptGroupInvitation(invitationID, userID)
+}
+
+func (g GroupStorageMock) CreateGroupTransaction(transaction model.GroupTransaction) (model.GroupTransaction, error) {
+	return MockCreateGroupTransaction(transaction)
 }

--- a/storage/mocks/group_storage_mock.go
+++ b/storage/mocks/group_storage_mock.go
@@ -13,7 +13,8 @@ var (
 	MockGroupGetGroups             func(uuid.UUID, uuid.UUID) ([]model.Group, error)
 	MockGroupDeleteGroup           func(uuid.UUID) error
 	MockGroupAcceptGroupInvitation func(uuid.UUID, uuid.UUID) error
-	MockCreateGroupTransaction     func(transaction model.GroupTransaction) (model.GroupTransaction, error)
+	MockGroupCreateTransaction     func(transaction model.GroupTransaction) (model.GroupTransaction, error)
+	MockGroupGetTransactions       func(uuid.UUID) ([]model.GroupTransaction, error)
 )
 
 func NewGroupStorageMock() storage.IGroupStorage {
@@ -48,5 +49,9 @@ func (g GroupStorageMock) AcceptGroupInvitation(invitationID uuid.UUID, userID u
 }
 
 func (g GroupStorageMock) CreateGroupTransaction(transaction model.GroupTransaction) (model.GroupTransaction, error) {
-	return MockCreateGroupTransaction(transaction)
+	return MockGroupCreateTransaction(transaction)
+}
+
+func (g GroupStorageMock) GetAllGroupTransactions(userID uuid.UUID) ([]model.GroupTransaction, error) {
+	return MockGroupGetTransactions(userID)
 }


### PR DESCRIPTION
I added 2 new tables: `group_transactions` and `transactions`. The workflow is as follows:

To clear a group you call `POST /group/{id}/transaction` with with id = group ID. All bills (and associations of a bill) get deleted. A new `group_transaction` is created with a date and potentially multiple `transaction` entries. Transactions store the creditor, debtor and an amount. This way we can get this data whenever we want.

With `GET /group/transaction` and query param `userId`, one can get all transactions for every group where the given user is member of (this is needed for our new screen in frontend).

Closes #155 