### PR TITLE
188: Ensure consistency on bill update

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1059,9 +1059,6 @@ const docTemplate = `{
         "dto.ItemInput": {
             "type": "object",
             "properties": {
-                "billId": {
-                    "type": "string"
-                },
                 "contributorIDs": {
                     "type": "array",
                     "items": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -885,6 +885,9 @@ const docTemplate = `{
                 },
                 "owner": {
                     "$ref": "#/definitions/dto.UserCoreOutput"
+                },
+                "updatedAt": {
+                    "type": "string"
                 }
             }
         },
@@ -904,6 +907,9 @@ const docTemplate = `{
                     }
                 },
                 "name": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1052,9 +1052,6 @@
         "dto.ItemInput": {
             "type": "object",
             "properties": {
-                "billId": {
-                    "type": "string"
-                },
                 "contributorIDs": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -878,6 +878,9 @@
                 },
                 "owner": {
                     "$ref": "#/definitions/dto.UserCoreOutput"
+                },
+                "updatedAt": {
+                    "type": "string"
                 }
             }
         },
@@ -897,6 +900,9 @@
                     }
                 },
                 "name": {
+                    "type": "string"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -123,8 +123,6 @@ definitions:
     type: object
   dto.ItemInput:
     properties:
-      billId:
-        type: string
       contributorIDs:
         items:
           type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -36,6 +36,8 @@ definitions:
         type: string
       owner:
         $ref: '#/definitions/dto.UserCoreOutput'
+      updatedAt:
+        type: string
     type: object
   dto.BillUpdate:
     properties:
@@ -48,6 +50,8 @@ definitions:
           $ref: '#/definitions/dto.ItemInput'
         type: array
       name:
+        type: string
+      updatedAt:
         type: string
     type: object
   dto.GeneralResponse:

--- a/domain/converter/converter.go
+++ b/domain/converter/converter.go
@@ -27,13 +27,14 @@ func ToBillDetailedDTO(bill model.Bill) dto.BillDetailedOutput {
 	}
 
 	return dto.BillDetailedOutput{
-		ID:      bill.ID,
-		Name:    bill.Name,
-		Date:    bill.Date,
-		Items:   itemsDTO,
-		Owner:   ToUserCoreDTO(&bill.Owner),
-		GroupID: bill.GroupID,
-		Balance: bill.Balance,
+		ID:        bill.ID,
+		UpdatedAt: bill.UpdatedAt,
+		Name:      bill.Name,
+		Date:      bill.Date,
+		Items:     itemsDTO,
+		Owner:     ToUserCoreDTO(&bill.Owner),
+		GroupID:   bill.GroupID,
+		Balance:   bill.Balance,
 	}
 }
 

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -4,4 +4,4 @@ import "errors"
 
 var ErrNotAuthorized = errors.New("not Authorized")
 var InvalidCredentials = errors.New("invalid credentials")
-var ErrNotAGroupMember = errors.New("contributor is not a member of the group")
+var ErrConcurrentModification = errors.New("concurrent modification")

--- a/domain/model/bill.go
+++ b/domain/model/bill.go
@@ -7,6 +7,7 @@ import (
 
 type Bill struct {
 	ID               uuid.UUID
+	UpdatedAt        time.Time
 	Owner            User
 	Name             string
 	Date             time.Time

--- a/domain/model/item.go
+++ b/domain/model/item.go
@@ -13,7 +13,7 @@ type Item struct {
 	Contributors []User
 }
 
-func CreateItem(id uuid.UUID, item dto.ItemInput) Item {
+func CreateItem(id uuid.UUID, billID uuid.UUID, item dto.ItemInput) Item {
 	// convert contributorIDs to simple UserModels
 	contributors := make([]User, len(item.Contributors))
 	for i, contributorID := range item.Contributors {
@@ -23,7 +23,7 @@ func CreateItem(id uuid.UUID, item dto.ItemInput) Item {
 		ID:           id,
 		Name:         item.Name,
 		Price:        item.Price,
-		BillID:       item.BillID,
+		BillID:       billID,
 		Contributors: contributors,
 	}
 }

--- a/domain/service/impl/bill_service.go
+++ b/domain/service/impl/bill_service.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"github.com/google/uuid"
+	"log"
 	"sort"
 	"split-the-bill-server/domain"
 	"split-the-bill-server/domain/converter"
@@ -40,13 +41,15 @@ func (b *BillService) Create(requesterID uuid.UUID, billDTO dto.BillCreate) (dto
 			unseenFrom = append(unseenFrom, member.ID)
 		}
 	}
+	// create new bill model including items
+	bill := model.CreateBill(uuid.New(), billDTO.OwnerID, billDTO.Name, billDTO.Date, billDTO.GroupID, nil, unseenFrom)
 	// create new items
 	var items []model.Item
 	for _, item := range billDTO.Items {
-		items = append(items, model.CreateItem(uuid.New(), item))
+		items = append(items, model.CreateItem(uuid.New(), bill.ID, item))
 	}
-	// create new bill model including items
-	bill := model.CreateBill(uuid.New(), billDTO.OwnerID, billDTO.Name, billDTO.Date, billDTO.GroupID, items, unseenFrom)
+	// add item to bill
+	bill.Items = items
 	// store bill in billStorage
 	bill, err = b.billStorage.Create(bill)
 	if err != nil {
@@ -62,13 +65,14 @@ func (b *BillService) Update(requesterID uuid.UUID, billID uuid.UUID, billDTO dt
 	if err != nil {
 		return dto.BillDetailedOutput{}, err
 	}
-
-	// check if an update happened in the meantime
+	// Check if an update happened in the meantime
 	updatedAt := bill.UpdatedAt.Truncate(time.Second)
 	if !updatedAt.Equal(billDTO.UpdatedAt) {
+		log.Println("Concurrent modification")
+		log.Println("Bill updated at: ", updatedAt)
+		log.Println("BillDTO updated at: ", billDTO.UpdatedAt)
 		return dto.BillDetailedOutput{}, domain.ErrConcurrentModification
 	}
-
 	// Get group
 	group, err := b.groupStorage.GetGroupByID(bill.GroupID)
 	if err != nil {
@@ -78,23 +82,24 @@ func (b *BillService) Update(requesterID uuid.UUID, billID uuid.UUID, billDTO dt
 	if !group.IsMember(requesterID) {
 		return dto.BillDetailedOutput{}, domain.ErrNotAuthorized
 	}
+
 	// delete user from unseen list if bill is viewed
 	if billDTO.Viewed {
 		bill.UnseenFromUserID = removeEntryFromSlice(bill.UnseenFromUserID, requesterID)
 	}
-
 	// update items if available
 	var items = bill.Items
 	if len(billDTO.Items) > 0 {
 		items = make([]model.Item, 0)
 		for _, item := range billDTO.Items {
-			items = append(items, model.CreateItem(uuid.New(), item))
+			items = append(items, model.CreateItem(uuid.New(), bill.ID, item))
 		}
 	}
-	// update bill fields: name, date, items, unseenFromUserID
-	updatedBill := model.CreateBill(bill.ID, bill.Owner.ID, billDTO.Name, billDTO.Date, bill.GroupID, items, bill.UnseenFromUserID)
-	updatedBill.ID = bill.ID
-	bill, err = b.billStorage.UpdateBill(updatedBill)
+	// update bill fields: name, date, items
+	bill.Name = billDTO.Name
+	bill.Date = billDTO.Date
+	bill.Items = items
+	bill, err = b.billStorage.UpdateBill(bill)
 	if err != nil {
 		return dto.BillDetailedOutput{}, err
 	}

--- a/domain/service/impl/bill_service.go
+++ b/domain/service/impl/bill_service.go
@@ -2,7 +2,6 @@ package impl
 
 import (
 	"github.com/google/uuid"
-	"log"
 	"sort"
 	"split-the-bill-server/domain"
 	"split-the-bill-server/domain/converter"
@@ -67,10 +66,7 @@ func (b *BillService) Update(requesterID uuid.UUID, billID uuid.UUID, billDTO dt
 	}
 	// Check if an update happened in the meantime
 	updatedAt := bill.UpdatedAt.Truncate(time.Second)
-	if !updatedAt.Equal(billDTO.UpdatedAt) {
-		log.Println("Concurrent modification")
-		log.Println("Bill updated at: ", updatedAt)
-		log.Println("BillDTO updated at: ", billDTO.UpdatedAt)
+	if !updatedAt.Equal(billDTO.UpdatedAt.Truncate(time.Second)) {
 		return dto.BillDetailedOutput{}, domain.ErrConcurrentModification
 	}
 	// Get group

--- a/integration_tests/bill_integration_test.go
+++ b/integration_tests/bill_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"split-the-bill-server/presentation/handler"
 	"split-the-bill-server/storage/database/entity"
 	"testing"
+	"time"
 )
 
 type BillResponseDTO struct {
@@ -58,6 +59,9 @@ func performBillRequest(httpMethod string, route string, inputUserData interface
 
 func TestUpdateBill(t *testing.T) {
 
+	// get the bill first
+	responseData, _, _ := performBillRequest(http.MethodGet, "/api/bill/"+Bill1.ID.String(), nil, &http.Cookie{Name: sessionCookie, Value: CookieUser1.ID.String()})
+
 	// Testdata
 	updatedItem1 := dto.ItemInput{
 		Name:         Item1.Name,
@@ -71,19 +75,18 @@ func TestUpdateBill(t *testing.T) {
 		Contributors: []uuid.UUID{User1.ID},
 	}
 
-	updatedBill := dto.BillCreate{
-		Name:    "Updated Bill",
-		OwnerID: User1.ID,
-		Date:    Bill1.Date,
-		GroupID: Group1.ID,
-		Items:   []dto.ItemInput{updatedItem1, updatedItem2},
+	updatedBill := dto.BillUpdate{
+		UpdatedAt: responseData.Data.UpdatedAt.Truncate(time.Second),
+		Name:      "Updated Bill",
+		Date:      Bill1.Date,
+		Items:     []dto.ItemInput{updatedItem1, updatedItem2},
 	}
 
 	route := "/api/bill/"
 	tests := []struct {
 		description        string // description of the testcase case
 		parameter          string
-		inputData          dto.BillCreate
+		inputData          dto.BillUpdate
 		cookie             *http.Cookie // cookie of the testcase
 		expectedCode       int          // expected HTTP status code
 		expectedMessage    string       // expected message in response body

--- a/presentation/dto/bill.go
+++ b/presentation/dto/bill.go
@@ -19,20 +19,22 @@ type BillCreate struct {
 }
 
 type BillUpdate struct {
-	Name   string      `json:"name"`
-	Date   time.Time   `json:"date"`
-	Viewed bool        `json:"isViewed,omitempty"`
-	Items  []ItemInput `json:"items,omitempty"`
+	UpdatedAt time.Time   `json:"updatedAt"`
+	Name      string      `json:"name"`
+	Date      time.Time   `json:"date"`
+	Viewed    bool        `json:"isViewed,omitempty"`
+	Items     []ItemInput `json:"items,omitempty"`
 }
 
 type BillDetailedOutput struct {
-	ID      uuid.UUID             `json:"id"`
-	Name    string                `json:"name"`
-	Date    time.Time             `json:"date"`
-	Items   []ItemOutput          `json:"items"`
-	GroupID uuid.UUID             `json:"groupID"`
-	Owner   UserCoreOutput        `json:"owner"`
-	Balance map[uuid.UUID]float64 `json:"balance,omitempty"` // include balance only if balance is set
+	ID        uuid.UUID             `json:"id"`
+	UpdatedAt time.Time             `json:"updatedAt"`
+	Name      string                `json:"name"`
+	Date      time.Time             `json:"date"`
+	Items     []ItemOutput          `json:"items"`
+	GroupID   uuid.UUID             `json:"groupID"`
+	Owner     UserCoreOutput        `json:"owner"`
+	Balance   map[uuid.UUID]float64 `json:"balance,omitempty"` // include balance only if balance is set
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/presentation/dto/item.go
+++ b/presentation/dto/item.go
@@ -12,7 +12,6 @@ import (
 type ItemInput struct {
 	Name         string      `json:"name"`
 	Price        float64     `json:"price"`
-	BillID       uuid.UUID   `json:"billId"`
 	Contributors []uuid.UUID `json:"contributorIDs"`
 }
 
@@ -35,12 +34,8 @@ func (i ItemInput) ValidateInputs() error {
 	if i.Price == 0 {
 		return ErrItemPriceRequired
 	}
-	if i.BillID == uuid.Nil {
-		return ErrItemBillIDRequired
-	}
 	return nil
 }
 
 var ErrItemNameRequired = errors.New("name is required")
 var ErrItemPriceRequired = errors.New("price is required")
-var ErrItemBillIDRequired = errors.New("billID is required")

--- a/presentation/dto/item_test.go
+++ b/presentation/dto/item_test.go
@@ -1,7 +1,6 @@
 package dto
 
 import (
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -15,35 +14,24 @@ func TestItemInput_ValidateInputs(t *testing.T) {
 		{
 			name: "Success",
 			input: ItemInput{
-				Name:   "Test",
-				Price:  10.0,
-				BillID: uuid.New(),
+				Name:  "Test",
+				Price: 10.0,
 			},
 			expectedErr: nil,
 		},
 		{
 			name: "Name is missing",
 			input: ItemInput{
-				Price:  10.0,
-				BillID: uuid.New(),
+				Price: 10.0,
 			},
 			expectedErr: ErrItemNameRequired,
 		},
 		{
 			name: "Price is missing",
 			input: ItemInput{
-				Name:   "Test",
-				BillID: uuid.New(),
+				Name: "Test",
 			},
 			expectedErr: ErrItemPriceRequired,
-		},
-		{
-			name: "BillID is missing",
-			input: ItemInput{
-				Name:  "Test",
-				Price: 10.0,
-			},
-			expectedErr: ErrItemBillIDRequired,
 		},
 	}
 

--- a/presentation/handler/bill_handler.go
+++ b/presentation/handler/bill_handler.go
@@ -122,6 +122,9 @@ func (h BillHandler) Update(c *fiber.Ctx) error {
 		if errors.Is(err, domain.ErrNotAuthorized) {
 			return Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgBillUpdate, err))
 		}
+		if errors.Is(err, domain.ErrConcurrentModification) {
+			return Error(c, fiber.StatusConflict, fmt.Sprintf(ErrMsgBillUpdate, err))
+		}
 		return Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgBillUpdate, err))
 	}
 

--- a/storage/database/converter/converter.go
+++ b/storage/database/converter/converter.go
@@ -74,6 +74,7 @@ func ToBillModel(bill entity.Bill) model.Bill {
 
 	return model.Bill{
 		ID:               bill.ID,
+		UpdatedAt:        bill.UpdatedAt,
 		Name:             bill.Name,
 		Date:             bill.Date,
 		Owner:            ToUserModel(bill.Owner),


### PR DESCRIPTION
Ensure consistency on bill update via comparing `updatedAt` from the `updateDTO` with `updatedAt` from the database to check whether an update happened in the meantime.

Closes #188 
Closes #191 