### PR TITLE
#188 Add separate item contribution update

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -238,6 +238,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/bill/{id}/contribution": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Bill"
+                ],
+                "summary": "Update Item Contribution",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bill ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request Body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ContributionInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.GeneralResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/group": {
             "get": {
                 "consumes": [
@@ -908,6 +948,17 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.ContributionInput": {
+            "type": "object",
+            "properties": {
+                "contribution": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.HasContributed"
+                    }
+                }
+            }
+        },
         "dto.GeneralResponse": {
             "type": "object",
             "properties": {
@@ -985,6 +1036,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/dto.TransactionOutput"
                     }
+                }
+            }
+        },
+        "dto.HasContributed": {
+            "type": "object",
+            "properties": {
+                "contributed": {
+                    "type": "boolean"
+                },
+                "itemID": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -231,6 +231,46 @@
                 }
             }
         },
+        "/api/bill/{id}/contribution": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Bill"
+                ],
+                "summary": "Update Item Contribution",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bill ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request Body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.ContributionInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.GeneralResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/group": {
             "get": {
                 "consumes": [
@@ -901,6 +941,17 @@
                 }
             }
         },
+        "dto.ContributionInput": {
+            "type": "object",
+            "properties": {
+                "contribution": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.HasContributed"
+                    }
+                }
+            }
+        },
         "dto.GeneralResponse": {
             "type": "object",
             "properties": {
@@ -978,6 +1029,17 @@
                     "items": {
                         "$ref": "#/definitions/dto.TransactionOutput"
                     }
+                }
+            }
+        },
+        "dto.HasContributed": {
+            "type": "object",
+            "properties": {
+                "contributed": {
+                    "type": "boolean"
+                },
+                "itemID": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -50,6 +50,13 @@ definitions:
       name:
         type: string
     type: object
+  dto.ContributionInput:
+    properties:
+      contribution:
+        items:
+          $ref: '#/definitions/dto.HasContributed'
+        type: array
+    type: object
   dto.GeneralResponse:
     properties:
       data: {}
@@ -102,6 +109,13 @@ definitions:
         items:
           $ref: '#/definitions/dto.TransactionOutput'
         type: array
+    type: object
+  dto.HasContributed:
+    properties:
+      contributed:
+        type: boolean
+      itemID:
+        type: string
     type: object
   dto.ItemInput:
     properties:
@@ -296,6 +310,32 @@ paths:
                   $ref: '#/definitions/dto.BillDetailedOutput'
               type: object
       summary: Update Bill
+      tags:
+      - Bill
+  /api/bill/{id}/contribution:
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Bill ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Request Body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.ContributionInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.GeneralResponse'
+      summary: Update Item Contribution
       tags:
       - Bill
   /api/group:

--- a/domain/service/bill_service_inf.go
+++ b/domain/service/bill_service_inf.go
@@ -26,4 +26,8 @@ type IBillService interface {
 	// If no filter is provided, all bills from the groups in which the user is a member are returned.
 	// *Authorization required: requester == userID
 	GetAllByUserID(requesterID uuid.UUID, userID uuid.UUID, isUnseen *bool, isOwner *bool) ([]dto.BillDetailedOutput, error)
+
+	// HandleContribution handles the item contribution of the requester to the bill with the given id.
+	// *Authorization required: requester in bill.Group.Members
+	HandleContribution(requesterID uuid.UUID, billID uuid.UUID, contribution dto.ContributionInput) error
 }

--- a/presentation/dto/item.go
+++ b/presentation/dto/item.go
@@ -16,6 +16,15 @@ type ItemInput struct {
 	Contributors []uuid.UUID `json:"contributorIDs"`
 }
 
+type ContributionInput struct {
+	Contribution []HasContributed `json:"contribution"`
+}
+
+type HasContributed struct {
+	ItemID      uuid.UUID `json:"itemID"`
+	Contributed bool      `json:"contributed"`
+}
+
 type ItemOutput struct {
 	ID           uuid.UUID        `json:"id"`
 	Name         string           `json:"name"`

--- a/presentation/handler/bill_handler.go
+++ b/presentation/handler/bill_handler.go
@@ -202,3 +202,41 @@ func (h BillHandler) GetAllByUser(c *fiber.Ctx) error {
 
 	return Success(c, fiber.StatusOK, SuccessMsgBillGetAll, bills)
 }
+
+// UpdateContribution 	updates the item contribution of the requester to the bill with the given id.
+//
+//	@Summary	Update Item Contribution
+//	@Tags		Bill
+//	@Accept		json
+//	@Produce	json
+//	@Param		id		path		string					true	"Bill ID"
+//	@Param		request	body		dto.ContributionInput	true	"Request Body"
+//	@Success	200		{object}	dto.GeneralResponse
+//	@Router		/api/bill/{id}/contribution [put]
+func (h BillHandler) UpdateContribution(c *fiber.Ctx) error {
+	// parse parameter
+	id := c.Params("id")
+	if id == "" {
+		return Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParameterRequired, "id"))
+	}
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgParseUUID, uid, err))
+	}
+	// parse request
+	var request dto.ContributionInput
+	if err = c.BodyParser(&request); err != nil {
+		return Error(c, fiber.StatusBadRequest, fmt.Sprintf(ErrMsgBillParse, err))
+	}
+	// get authenticated requester from context
+	requesterID := c.Locals(middleware.UserKey).(uuid.UUID)
+	// update item contribution
+	err = h.billService.HandleContribution(requesterID, uid, request)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotAuthorized) {
+			return Error(c, fiber.StatusUnauthorized, fmt.Sprintf(ErrMsgBillUpdate, err))
+		}
+		return Error(c, fiber.StatusInternalServerError, fmt.Sprintf(ErrMsgBillUpdate, err))
+	}
+	return Success(c, fiber.StatusOK, SuccessMsgBillUpdate, nil)
+}

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -53,6 +53,7 @@ func SetupRoutes(app *fiber.App, u UserHandler, g GroupHandler, b BillHandler, a
 	billRoute.Get("/:id", a.Authenticate, b.GetByID)
 	billRoute.Delete("/:id", a.Authenticate, b.Delete)
 	billRoute.Get("/", a.Authenticate, b.GetAllByUser)
+	billRoute.Put("/:id/contribution", a.Authenticate, b.UpdateContribution)
 
 	// group routes
 	groupRoute := api.Group("/group")

--- a/presentation/router/router.go
+++ b/presentation/router/router.go
@@ -49,11 +49,11 @@ func SetupRoutes(app *fiber.App, u UserHandler, g GroupHandler, b BillHandler, a
 	billRoute := api.Group("/bill")
 	// routes
 	billRoute.Post("/", a.Authenticate, b.Create)
+	billRoute.Put("/:id/contribution", a.Authenticate, b.UpdateContribution)
 	billRoute.Put("/:id", a.Authenticate, b.Update)
 	billRoute.Get("/:id", a.Authenticate, b.GetByID)
 	billRoute.Delete("/:id", a.Authenticate, b.Delete)
 	billRoute.Get("/", a.Authenticate, b.GetAllByUser)
-	billRoute.Put("/:id/contribution", a.Authenticate, b.UpdateContribution)
 
 	// group routes
 	groupRoute := api.Group("/group")


### PR DESCRIPTION
Now the contribution of a user to all items from a bill can be done separately. This allows multiple users to change their contribution simultaneously.  
